### PR TITLE
Mount the drives on request

### DIFF
--- a/pkg/apis/direct.csi.min.io/v1alpha1/types.go
+++ b/pkg/apis/direct.csi.min.io/v1alpha1/types.go
@@ -81,7 +81,8 @@ type DriveStatus string
 const (
 	Online      DriveStatus = "online"
 	Offline                 = "offline"
-	Unformatted             = "new"
+	Unformatted             = "unformatted"
+	New                     = "new"
 	Other                   = "other"
 )
 

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -17,17 +17,13 @@
 package controller
 
 import (
-	"path/filepath"
 	"sort"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/golang/glog"
+
 	direct_csi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
-	"github.com/pborman/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/utils/exec"
-	"k8s.io/utils/mount"
 )
 
 // FilterDrivesByVolumeRequest - Filters the CSI drives by create volume request
@@ -132,17 +128,4 @@ func matchSegments(topSegments, driveSegments map[string]string) bool {
 		}
 	}
 	return req == match
-}
-
-// MountDevice - Utility to mount a device in `/mnt/<uid>`
-func MountDevice(devicePath string) (string, error) {
-	mountID := uuid.NewUUID().String()
-	mountPath := filepath.Join("/mnt", mountID)
-	// FormatAndMount formats the given disk, if needed, and mounts it
-	diskMounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: exec.New()}
-	if err := diskMounter.FormatAndMount(devicePath, mountPath, "", []string{}); err != nil {
-		glog.V(5).Info(err)
-		return "", err
-	}
-	return mountPath, nil
 }

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -133,7 +133,7 @@ func NewDefaultDirectCSIController(identity string, leaderLockName string, threa
 
 func NewDirectCSIController(identity string, leaderLockName string, threads int, limiter workqueue.RateLimiter) (*DirectCSIController, error) {
 	cfg, err := func() (*rest.Config, error) {
-		kubeConfig := viper.GetString("kube-config")
+		kubeConfig := viper.GetString("kubeconfig")
 
 		if kubeConfig != "" {
 			return clientcmd.BuildConfigFromFlags("", kubeConfig)
@@ -317,14 +317,14 @@ func (c *DirectCSIController) GetOpLock(op interface{}) *sync.Mutex {
 		panic("unknown item in queue")
 	}
 
+	c.lockerLock.Lock()
+	defer c.lockerLock.Unlock()
 	lockKey := fmt.Sprintf("%s/%s", key, ext)
 	if c.locker == nil {
 		c.locker = map[string]*sync.Mutex{}
 	}
 	if _, ok := c.locker[lockKey]; !ok {
-		c.lockerLock.Lock()
 		c.locker[lockKey] = &sync.Mutex{}
-		c.lockerLock.Unlock()
 	}
 	return c.locker[lockKey]
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -57,6 +57,8 @@ func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region str
 		}
 	}
 
+	go startController(ctx)
+
 	return &NodeServer{
 		NodeID:    nodeID,
 		Identity:  identity,

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -331,6 +331,9 @@ func WalkWithFollow(path string, callback func(path string, info os.FileInfo, er
 
 // MountDevice - Utility to mount a device in the given mountpoint
 func MountDevice(devicePath, mountPoint, fsType string, options []string) error {
+	if err := os.MkdirAll(mountPoint, 0755); err != nil {
+		return err
+	}
 	if err := mount.New("").Mount(devicePath, mountPoint, fsType, options); err != nil {
 		glog.V(5).Info(err)
 		return err

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -20,7 +20,10 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/golang/glog"
 	"io/ioutil"
+	"k8s.io/utils/exec"
+	"k8s.io/utils/mount"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -319,6 +322,16 @@ func WalkWithFollow(path string, callback func(path string, info os.FileInfo, er
 				return nil
 			}
 		}
+	}
+	return nil
+}
+
+// MountDevice - Utility to mount a device in `/mnt/<uid>`
+func MountDevice(devicePath, mountPoint, fsType string, options []string) error {
+	diskMounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: exec.New()}
+	if err := diskMounter.FormatAndMount(devicePath, mountPoint, fsType, options); err != nil {
+		glog.V(5).Info(err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
- Listen for RequestedFormat changes in DirectCSIDrive object updates
  and mount the drives accordingly
- Formatting will be done separately. These changes will assume that the drives are already formatted before presenting.

Verified the functionality by updating the yaml and applying it directly (declarative). And checking if the drive status is changing to "online" after applying.