### PR TITLE
Revert "feat(node): Rework FindDrives (#58)" and bugfixes

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -43,7 +43,7 @@ func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region str
 	topologies[topology.TopologyDriverIdentity] = identity
 	topologies[topology.TopologyDriverRack] = rack
 	topologies[topology.TopologyDriverZone] = zone
-	topologies[topology.TopologyDriverZone] = zone
+	topologies[topology.TopologyDriverRegion] = region
 	topologies[topology.TopologyDriverNode] = nodeID
 	driveTopology := topologies
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -49,7 +49,7 @@ func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region str
 
 	for _, drive := range drives {
 		drive.Status.Topology = driveTopology
-		_, err := directCSIClient.DirectCSIDrives().Create(ctx, &drive, metav1.CreateOptions{})
+		_, err := directCSIClient.DirectCSIDrives().Create(ctx, drive, metav1.CreateOptions{})
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return nil, err


### PR DESCRIPTION
This reverts commit 511459038721d521a425e4f8d547651889271598.

listing disks by id is inconsistent among different versions of sysfs

Note: Also fixes the drive's topology by adding region