### PR TITLE
fix(scripts): Take bash from PATH

### DIFF
--- a/add-license-header.sh
+++ b/add-license-header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cat > /tmp/LICENSE_TEMPLATE << EOF
 This file is part of MinIO Direct CSI

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of MinIO Direct CSI
 # Copyright (c) 2020 MinIO, Inc.


### PR DESCRIPTION
 Not all distributions have `bash` under `/bin/bash` (such as NixOS), but usually they do at least have `env` under `/usr/bin/env` because I think `/usr/bin/env` is needed for POSIX compliance.