### PR TITLE
probe mountinfo for each blockdevice

### DIFF
--- a/pkg/dev/fs.go
+++ b/pkg/dev/fs.go
@@ -29,10 +29,11 @@ var ErrNoFS = errors.New("No FS found")
 type FSType string
 
 type FSInfo struct {
-	FSType        FSType `json:"fsType,omitempty"`
-	TotalCapacity uint64 `json:"totalCapacity,omitempty"`
-	FreeCapacity  uint64 `json:"freeCapacity,omitempty"`
-	FSBlockSize   uint64 `json:"fsBlockSize,omitempty"`
+	FSType        FSType  `json:"fsType,omitempty"`
+	TotalCapacity uint64  `json:"totalCapacity,omitempty"`
+	FreeCapacity  uint64  `json:"freeCapacity,omitempty"`
+	FSBlockSize   uint64  `json:"fsBlockSize,omitempty"`
+	Mounts        []Mount `json:"mounts,omitempty"`
 }
 
 func ProbeFS(devName string, logicalBlockSize uint64, offsetBlocks uint64) (*FSInfo, error) {
@@ -77,6 +78,7 @@ func ProbeFSEXT4(devName string, logicalBlockSize uint64, offsetBlocks uint64) (
 		FSBlockSize:   fsBlockSize,
 		TotalCapacity: uint64(ext4.NumBlocks) * uint64(fsBlockSize),
 		FreeCapacity:  uint64(ext4.FreeBlocks) * uint64(fsBlockSize),
+		Mounts:        []Mount{},
 	}
 
 	return fsInfo, nil

--- a/pkg/dev/mount.go
+++ b/pkg/dev/mount.go
@@ -1,0 +1,116 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dev
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type Mount struct {
+	MountPoint        string   `json:"mountPoint,omitempty"`
+	MountFlags        []string `json:"mountFlags,omitempty"`
+	MountRoot         string   `json:"mountRoot,omitempty"`
+	MountID           uint32   `json:"mountID,omitempty"`
+	ParentID          uint32   `json:"parentID,omitempty"`
+	MountSource       string   `json:"mountSource,omitempty"`
+	SuperblockOptions []string `json:"superblockOptions,omitempty"`
+	FSType            FSType   `json:"fsType,omitempty"`
+	OptionalFields    []string `json:"optionalFields,omitempty"`
+}
+
+func ProbeMounts(procfs string, devName string, partitionNum uint) ([]Mount, error) {
+	mountinfoFile := filepath.Join(procfs, "1", "mountinfo")
+	f, err := os.Open(mountinfoFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	mounts := []Mount{}
+	fbuf := bufio.NewReader(f)
+
+	for {
+		line, err := fbuf.ReadString(byte('\n'))
+		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
+			break
+		}
+		devName := filepath.Join(DevRoot, devName)
+		// usual naming scheme
+		if strings.Contains(line, devName) {
+			parts := strings.SplitN(line, "-", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid format of %s 1", mountinfoFile)
+			}
+			firstParts := strings.Fields(strings.TrimSpace(parts[0]))
+			if len(firstParts) < 7 {
+				return nil, fmt.Errorf("invalid format of %s 2", mountinfoFile)
+			}
+			mID, err := strconv.ParseUint(firstParts[0], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid format of %s 3", mountinfoFile)
+			}
+			mountID := uint32(mID)
+
+			pID, err := strconv.ParseUint(firstParts[1], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid format of %s 4", mountinfoFile)
+			}
+			parentID := uint32(pID)
+
+			mountRoot := firstParts[3]
+			mountPoint := firstParts[4]
+			mountOptions := firstParts[5]
+			optionalFields := firstParts[6:]
+			mountFlags := strings.Split(mountOptions, ",")
+
+			secondParts := strings.Fields(strings.TrimSpace(parts[1]))
+			if len(secondParts) < 3 {
+				return nil, fmt.Errorf("invalid format of %s 5", mountinfoFile)
+			}
+
+			fsType := FSType(secondParts[0])
+			mountSource := secondParts[1]
+			if !strings.HasSuffix(mountSource, fmt.Sprintf("%d", partitionNum)) {
+				continue
+			}
+			superblockOptions := strings.Split(secondParts[2], ",")
+			fmt.Println("found mount", line)
+
+			mounts = append(mounts, Mount{
+				MountPoint:        mountPoint,
+				MountFlags:        mountFlags,
+				MountRoot:         mountRoot,
+				MountID:           mountID,
+				ParentID:          parentID,
+				MountSource:       mountSource,
+				SuperblockOptions: superblockOptions,
+				FSType:            fsType,
+				OptionalFields:    optionalFields,
+			})
+		}
+	}
+	return mounts, nil
+}

--- a/pkg/dev/partitions.go
+++ b/pkg/dev/partitions.go
@@ -31,6 +31,7 @@ var ErrNotGPT = errors.New("Not a GPT volume")
 type Partition struct {
 	PartitionNum  uint32 `json:"partitionNum,omitempty"`
 	Type          string `json:"partitionType,omitempty"`
+	TypeUUID      string `json:"partitionTypeUUID,omitempty"`
 	PartitionGUID string `json:"partitionGUID,omitempty"`
 	DiskGUID      string `json:"diskGUID,omitempty"`
 
@@ -105,6 +106,7 @@ func (b *BlockDevice) FindPartitions() ([]Partition, error) {
 			},
 			PartitionNum:  i + 1,
 			Type:          partType,
+			TypeUUID:      partTypeUUID,
 			PartitionGUID: stringifyUUID(lba.PartitionGUID),
 			DiskGUID:      stringifyUUID(gpt.DiskGUID),
 		}


### PR DESCRIPTION
The format of mountinfo is guaranteed to be stable across kernel versions. See https://man7.org/linux/man-pages/man5/proc.5.html  (search for /proc/[pid]/mountinfo)