### PR TITLE
Do not miss the initial mounts during drive-discovery

### DIFF
--- a/pkg/dev/mount.go
+++ b/pkg/dev/mount.go
@@ -57,9 +57,9 @@ func ProbeMounts(procfs string, devName string, partitionNum uint) ([]Mount, err
 			}
 			break
 		}
-		devName := getBlockFile(devName)
+		newDevName := getBlockFile(devName)
 		// usual naming scheme
-		if strings.Contains(line, devName) {
+		if strings.Contains(line, newDevName) || strings.Contains(line, filepath.Join("/dev", devName)) {
 			parts := strings.SplitN(line, " - ", 2)
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("invalid format of %s 1", mountinfoFile)


### PR DESCRIPTION
Direct-csi creates a block file during discovery as `/var/lib/direct-csi/devices/<deviceName>`.
The mount discovery should not miss the old(initial) mounts.

For eg,

Initially, the mounts should be lying on `/dev/xvdb` and in such cases, the mountinfo would look like

```
~ cat /proc/1/mountinfo | grep /dev/xvdb
31 29 202:16 / /var/lib/direct-csi/dcsimount rw,relatime shared:4 - xfs /dev/xvdb rw,attr2,inode64,logbufs=8,logbsize=32k,noquota
```

We were looking for `grep /var/lib/direct-csi/devices/xvdb` alone and missing the mounts during the drive discovery.