### PR TITLE
Move periodic volume stat updates to node controller

### DIFF
--- a/cmd/kubectl-direct_csi/list-volumes.go
+++ b/cmd/kubectl-direct_csi/list-volumes.go
@@ -125,7 +125,7 @@ func (l *csiListVolumesCmd) run(args []string) error {
 		t.AppendRow(table.Row{
 			v.Name,
 			v.Status.OwnerNode,
-			v.Status.HostPath,
+			v.Status.OwnerDrive,
 			humanize.SI(float64(v.Status.TotalCapacity), "B"),
 			"", //TODO: Add Bind Status
 		})

--- a/pkg/node/drive_controller.go
+++ b/pkg/node/drive_controller.go
@@ -198,39 +198,35 @@ func startDriveController(ctx context.Context, nodeID string) error {
 	return ctrl.Run(ctx)
 }
 
-func refreshVolumeStats(ctx context.Context, nodeID string) {
-	retryTicker := time.NewTicker(5 * time.Minute)
-	defer retryTicker.Stop()
+func refreshVolumeStats(ctx context.Context, nodeID string, refreshTimeInterval time.Duration) {
+	refreshTicker := time.NewTicker(refreshTimeInterval)
+	defer refreshTicker.Stop()
 
 	directCSIClient := utils.GetDirectCSIClient()
 	refreshStatsFunc := func(dvol direct_csi.DirectCSIVolume) error {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if utils.CheckVolumeStatusCondition(dvol.Status.Conditions, "published", metav1.ConditionTrue) {
-				sc := utils.GetVolumeStatusCondition(dvol.Status.Conditions, "volumestats")
-				duration := time.Since(sc.LastTransitionTime.Time)
-				if duration > 5*time.Minute {
-					xfsQuota := &dev.XFSQuota{
-						Path:      dvol.Status.StagingPath,
-						ProjectID: dvol.ObjectMeta.Name,
-					}
-					volStats, err := xfsQuota.GetVolumeStats(ctx)
-					if err != nil {
-						return err
-					}
-					dvol.Status.TotalCapacity = volStats.TotalBytes
-					dvol.Status.AvailableCapacity = volStats.AvailableBytes
-					dvol.Status.UsedCapacity = volStats.UsedBytes
-					utils.UpdateVolumeStatusCondition(dvol.Status.Conditions, "volumestats", metav1.ConditionTrue)
-					if _, vErr := directCSIClient.DirectCSIVolumes().Update(ctx, &dvol, metav1.UpdateOptions{}); vErr != nil {
-						if errors.IsConflict(vErr) {
-							dvolPtr, cErr := directCSIClient.DirectCSIVolumes().Get(ctx, dvol.ObjectMeta.Name, metav1.GetOptions{})
-							if cErr != nil {
-								return cErr
-							}
-							dvol = *dvolPtr
+				xfsQuota := &dev.XFSQuota{
+					Path:      dvol.Status.StagingPath,
+					ProjectID: dvol.ObjectMeta.Name,
+				}
+				volStats, err := xfsQuota.GetVolumeStats(ctx)
+				if err != nil {
+					return err
+				}
+				dvol.Status.TotalCapacity = volStats.TotalBytes
+				dvol.Status.AvailableCapacity = volStats.AvailableBytes
+				dvol.Status.UsedCapacity = volStats.UsedBytes
+				utils.UpdateVolumeStatusCondition(dvol.Status.Conditions, "volumestats", metav1.ConditionTrue)
+				if _, vErr := directCSIClient.DirectCSIVolumes().Update(ctx, &dvol, metav1.UpdateOptions{}); vErr != nil {
+					if errors.IsConflict(vErr) {
+						dvolPtr, cErr := directCSIClient.DirectCSIVolumes().Get(ctx, dvol.ObjectMeta.Name, metav1.GetOptions{})
+						if cErr != nil {
+							return cErr
 						}
-						return vErr
+						dvol = *dvolPtr
 					}
+					return vErr
 				}
 			}
 			return nil
@@ -243,7 +239,7 @@ func refreshVolumeStats(ctx context.Context, nodeID string) {
 
 	for {
 		select {
-		case <-retryTicker.C:
+		case <-refreshTicker.C:
 			volList, cErr := directCSIClient.DirectCSIVolumes().List(ctx, metav1.ListOptions{})
 			if cErr != nil {
 				glog.V(4).Infof("Error while listing volumes %v", cErr)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -19,6 +19,7 @@ package node
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
@@ -32,6 +33,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/util/retry"
+)
+
+const (
+	volumeStatsRefreshInterval = 5 * time.Minute
 )
 
 func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region string, basePaths []string, procfs string) (*NodeServer, error) {
@@ -77,7 +82,7 @@ func NewNodeServer(ctx context.Context, identity, nodeID, rack, zone, region str
 	go startDriveController(ctx, nodeID)
 
 	// Start volume stats refresher
-	go refreshVolumeStats(ctx, nodeID)
+	go refreshVolumeStats(ctx, nodeID, volumeStatsRefreshInterval)
 
 	return &NodeServer{
 		NodeID:    nodeID,


### PR DESCRIPTION
The volume controller instances will not be running on all nodes and running xfs_quota reports on volume controller is not usefull in collecting stats. 

volume stat updates are specific to node controller so this PR spins a thread on all the nodes to refresh the stats with a ticker of 5mins.