### PR TITLE
Setup Validation admission controllers for DirectCSI drives and volumes

### DIFF
--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -120,5 +120,12 @@ func install(ctx context.Context, args []string) error {
 	}
 	glog.Infof("'%s' deployment created", utils.Bold(identity))
 
+	if err := installer.RegisterDriveValidationRules(ctx, identity); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	glog.Infof("'%s' drive validation rules registered", utils.Bold(identity))
+
 	return nil
 }

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -145,6 +145,20 @@ func uninstall(ctx context.Context, args []string) error {
 	}
 	glog.Infof("'%s' daemonset deleted", utils.Bold(identity))
 
+	if err := installer.DeleteDriveValidationRules(ctx, identity); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	glog.Infof("'%s' drive validation rules removed", utils.Bold(identity))
+
+	if err := installer.DeleteSecrets(ctx, identity); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	glog.Infof("'%s' secrets deleted", utils.Bold(identity))
+
 	if err := installer.DeleteDeployment(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -150,14 +150,13 @@ func uninstall(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	glog.Infof("'%s' drive validation rules removed", utils.Bold(identity))
 
 	if err := installer.DeleteSecrets(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	glog.Infof("'%s' secrets deleted", utils.Bold(identity))
+	glog.Infof("'%s' drive validation rules removed", utils.Bold(identity))
 
 	if err := installer.DeleteDeployment(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {

--- a/pkg/controller/admission_controller.go
+++ b/pkg/controller/admission_controller.go
@@ -1,0 +1,72 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package controller
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+const (
+	port              = "443"
+	certPath          = "/etc/certs/cert.pem"
+	keyPath           = "/etc/certs/key.pem"
+	driveHandlerPath  = "/validatedrive"
+	volumeHandlerPath = "/validatevolume"
+)
+
+func serveAdmissionController(ctx context.Context) {
+	certs, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		glog.Errorf("Filed to load key pair: %v", err)
+	}
+
+	// Create a secure http server
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%v", port),
+		TLSConfig: &tls.Config{
+			Certificates:       []tls.Certificate{certs},
+			InsecureSkipVerify: true,
+		},
+	}
+
+	// define http server and server handler
+	vh := ValidationHandler{}
+	mux := http.NewServeMux()
+	mux.HandleFunc(driveHandlerPath, vh.validateDrive)
+	mux.HandleFunc(volumeHandlerPath, vh.validateVolume)
+	server.Handler = mux
+
+	// start webhook server in new rountine
+	go func() {
+		if err := server.ListenAndServeTLS("", ""); err != nil {
+			glog.Errorf("Failed to listen and serve admission webhook server: %v", err)
+		}
+	}()
+
+	glog.V(5).Infof("controller manager started")
+	glog.Infof("Admission webhook server started and listening in port: %s", port)
+
+	<-ctx.Done()
+
+	glog.Info("Got shutdown signal, shutting down admission webhook server gracefully")
+	server.Shutdown(context.Background())
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -71,6 +71,9 @@ import (
  */
 
 func NewControllerServer(ctx context.Context, identity, nodeID, rack, zone, region string) (*ControllerServer, error) {
+	// Start admission webhook server
+	go serveAdmissionController(ctx)
+
 	return &ControllerServer{
 		NodeID:   nodeID,
 		Identity: identity,

--- a/pkg/controller/validation-handlers.go
+++ b/pkg/controller/validation-handlers.go
@@ -1,0 +1,180 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+
+	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	FailureStatus = "Failure"
+	SuccessStatus = "Success"
+)
+
+type ValidationHandler struct {
+}
+
+func parseAdmissionReview(req *http.Request) (admissionv1.AdmissionReview, error) {
+	var body []byte
+	admissionReview := admissionv1.AdmissionReview{}
+
+	if req.Method != http.MethodPost {
+		return admissionReview, errors.New("Invalid HTTP Method")
+	}
+
+	if req.Body != nil {
+		if data, err := ioutil.ReadAll(req.Body); err == nil {
+			body = data
+		}
+	}
+	if len(body) == 0 {
+		return admissionReview, errors.New("Request body empty")
+	}
+
+	if err := json.Unmarshal(body, &admissionReview); err != nil {
+		return admissionReview, err
+	}
+
+	return admissionReview, nil
+}
+
+func writeSuccessResponse(admissionReview admissionv1.AdmissionReview, w http.ResponseWriter) {
+	resp, err := json.Marshal(admissionReview)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)
+	}
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(resp); err != nil {
+		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
+	}
+	w.(http.Flusher).Flush()
+}
+
+func validateRequestedFormat(directCSIDrive directv1alpha1.DirectCSIDrive, admissionReview *admissionv1.AdmissionReview) bool {
+	requestedFormat := directCSIDrive.Spec.RequestedFormat
+
+	if reflect.DeepEqual(requestedFormat, directv1alpha1.RequestedFormat{}) {
+		return true
+	}
+
+	if directCSIDrive.Status.DriveStatus == directv1alpha1.DriveStatusUnavailable || directCSIDrive.Status.Mountpoint == "/" {
+		admissionReview.Response.Allowed = false
+		admissionReview.Response.Result = &metav1.Status{
+			Status:  FailureStatus,
+			Message: "Root partition'ed drives cannot be added/formatted",
+		}
+		return false
+	}
+
+	if directCSIDrive.Status.DriveStatus == directv1alpha1.DriveStatusInUse {
+		admissionReview.Response.Allowed = false
+		admissionReview.Response.Result = &metav1.Status{
+			Status:  FailureStatus,
+			Message: "Drives in-use cannot be formatted and added",
+		}
+		return false
+	}
+
+	if requestedFormat.Filesystem != "" && requestedFormat.Filesystem != "xfs" {
+		admissionReview.Response.Allowed = false
+		admissionReview.Response.Result = &metav1.Status{
+			Status:  FailureStatus,
+			Message: "DirectCSI supports only xfs filesystem format",
+		}
+		return false
+	}
+
+	if directCSIDrive.Status.Filesystem != "" || directCSIDrive.Status.Mountpoint != "" {
+		if !requestedFormat.Force {
+			admissionReview.Response.Allowed = false
+			admissionReview.Response.Result = &metav1.Status{
+				Status:  FailureStatus,
+				Message: "Force flag must be set to override the format and remount",
+			}
+			return false
+		}
+	}
+
+	return true
+}
+
+/* Validates the following admission rules
+   - Check if the fstype in the requestedFormat == "xfs"
+   - Check if directCSIOwned is not set to True or requestedFormat is set for root partitions (unavailable drives)
+   - Check if requestedFormat is not set for a drive in-use
+   - Check if force option is set if the drive has an existing filesystem or mountpoint
+*/
+func (vh *ValidationHandler) validateDrive(w http.ResponseWriter, r *http.Request) {
+
+	admissionReview, err := parseAdmissionReview(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to parse the body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	rawObj := admissionReview.Request.Object.Raw
+
+	dcsiDrive := directv1alpha1.DirectCSIDrive{}
+	if err := json.Unmarshal(rawObj, &dcsiDrive); err != nil {
+		http.Error(w, fmt.Sprintf("could not parse directCSI object: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	admissionReview.Response = &admissionv1.AdmissionResponse{
+		UID:     admissionReview.Request.UID,
+		Allowed: true,
+	}
+
+	if !validateRequestedFormat(dcsiDrive, &admissionReview) {
+		writeSuccessResponse(admissionReview, w)
+		return
+	}
+
+	writeSuccessResponse(admissionReview, w)
+}
+
+// To-Do: Volume updates other than conditions shouldn't be allowed.
+func (vh *ValidationHandler) validateVolume(w http.ResponseWriter, r *http.Request) {
+
+	admissionReview, err := parseAdmissionReview(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to parse the body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	//
+	//
+	// Add validation logic
+	//
+	//
+
+	admissionReview.Response = &admissionv1.AdmissionResponse{
+		UID:     admissionReview.Request.UID,
+		Allowed: true,
+	}
+
+	writeSuccessResponse(admissionReview, w)
+}

--- a/pkg/utils/installer/certs.go
+++ b/pkg/utils/installer/certs.go
@@ -1,0 +1,120 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package installer
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+)
+
+func getCerts(dnsNames []string) (caCertBytes, publicCertBytes, privateKeyBytes []byte, err error) {
+	// set up our CA certificate
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"MinIO, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Palo Alto"},
+			StreetAddress: []string{"University Ave Ste B"},
+			PostalCode:    []string{"94301"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// create our private and public key
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return []byte(""), []byte(""), []byte(""), err
+	}
+
+	// create the CA
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return []byte(""), []byte(""), []byte(""), err
+	}
+
+	// pem encode
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	caCertBytes = caPEM.Bytes()
+
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+
+	// set up our server certificate
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"MinIO, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Palo Alto"},
+			StreetAddress: []string{"University Ave Ste B"},
+			PostalCode:    []string{"94301"},
+		},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return []byte(""), []byte(""), []byte(""), err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return []byte(""), []byte(""), []byte(""), err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	publicCertBytes = certPEM.Bytes()
+
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+	privateKeyBytes = certPrivKeyPEM.Bytes()
+
+	return
+}

--- a/pkg/utils/installer/install.go
+++ b/pkg/utils/installer/install.go
@@ -733,7 +733,7 @@ func getDriveValidatingWebhookConfig(identity string) admissionv1.ValidatingWebh
 	getValidationRules := func() []admissionv1.RuleWithOperations {
 		return []admissionv1.RuleWithOperations{
 			{
-				Operations: []admissionv1.OperationType{admissionv1.Create, admissionv1.Update},
+				Operations: []admissionv1.OperationType{admissionv1.Update},
 				Rule: admissionv1.Rule{
 					APIGroups:   []string{"*"},
 					APIVersions: []string{"*"},

--- a/pkg/utils/installer/install.go
+++ b/pkg/utils/installer/install.go
@@ -32,7 +32,7 @@ import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kErr "k8s.io/apimachinery/pkg/api/errors"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -604,7 +604,7 @@ func CreateDeployment(ctx context.Context, identity string, directCSIContainerIm
 	caBundle = caCertBytes
 
 	if err := CreateControllerSecret(ctx, identity, publicCertBytes, privateKeyBytes); err != nil {
-		if !kErr.IsAlreadyExists(err) {
+		if !kerr.IsAlreadyExists(err) {
 			return err
 		}
 	}

--- a/pkg/utils/installer/install.go
+++ b/pkg/utils/installer/install.go
@@ -32,7 +32,7 @@ import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k8sErr "k8s.io/apimachinery/pkg/api/errors"
+	kErr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -604,7 +604,7 @@ func CreateDeployment(ctx context.Context, identity string, directCSIContainerIm
 	caBundle = caCertBytes
 
 	if err := CreateControllerSecret(ctx, identity, publicCertBytes, privateKeyBytes); err != nil {
-		if !k8sErr.IsAlreadyExists(err) {
+		if !kErr.IsAlreadyExists(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
- Add the following rules in drive validation

```
 - Check if the fstype in the requestedFormat == "xfs"
 - Check if directCSIOwned is not set to True or requestedFormat is set for root partitions (unavailable drives)
 - Check if requestedFormat is not set for a drive in-use
 - Check if force option is set if the drive has an existing filesystem or mountpoint
```

- Also, Register and unregister drive validation controller and rules during install/un-install direct-csi commands
- Create a controller service for the central-controller deployment for the validation webhook server
