### PR TITLE
Add pod labels to the DirectCSIVolume while publishing volume and BugFixes

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         app: minio
+        direct.csi.min.io/organization: minio
+        direct.csi.min.io/app: minio-example
     spec:
       containers:
       - name: minio

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
 	"github.com/minio/direct-csi/pkg/utils"
@@ -293,14 +292,11 @@ func (c *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 	}
 
-	volumeContext := req.GetParameters()
-	volumeContext["RequiredBytes"] = fmt.Sprintf("%d", size)
-
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      name,
 			CapacityBytes: size,
-			VolumeContext: volumeContext,
+			VolumeContext: req.GetParameters(),
 			ContentSource: req.GetVolumeContentSource(),
 			AccessibleTopology: []*csi.Topology{
 				{

--- a/pkg/node/stage_unstage.go
+++ b/pkg/node/stage_unstage.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
 	"github.com/minio/direct-csi/pkg/sys"
@@ -63,18 +62,12 @@ func (n *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
-	var size int64
-	if val, ok := req.GetVolumeContext()["RequiredBytes"]; ok {
-		size, err = strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "invalid volume size [%s]: %v", val, err)
-		}
-	}
 	path := filepath.Join(drive.Status.Mountpoint, vID)
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return nil, err
 	}
 
+	size := vol.Status.TotalCapacity
 	if err := mountVolume(ctx, path, stagingTargetPath, vID, size, false); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed stage volume: %v", err)
 	}

--- a/pkg/utils/installer/install.go
+++ b/pkg/utils/installer/install.go
@@ -127,7 +127,7 @@ func CreateNamespace(ctx context.Context, identity string) error {
 }
 
 func CreateCSIDriver(ctx context.Context, identity string) error {
-	podInfoOnMount := false
+	podInfoOnMount := true
 	attachRequired := false
 
 	gvk, err := utils.GetGroupKindVersions("storage.k8s.io", "CSIDriver", "v1", "v1beta1", "v1alpha1")

--- a/pkg/utils/installer/rbac.go
+++ b/pkg/utils/installer/rbac.go
@@ -296,6 +296,20 @@ func createClusterRole(ctx context.Context, identity string) error {
 					"direct.csi.min.io",
 				},
 			},
+			{
+				Verbs: []string{
+					clusterRoleVerbGet,
+					clusterRoleVerbList,
+					clusterRoleVerbWatch,
+				},
+				Resources: []string{
+					"pods",
+					"pod",
+				},
+				APIGroups: []string{
+					"",
+				},
+			},
 		},
 		AggregationRule: nil,
 	}


### PR DESCRIPTION
Attach the pod labels prefixed with `direct.csi.min.io` such as pod names and namespaces to the DirectCSIVolume, Which can be used to filter the volume listings.

Also, Remove the volumeContext - `RequiredBytes` probe from the CreateVolume and use Volume's totalCapacity instead