### PR TITLE
fix kubectl direct-csi --help

### DIFF
--- a/cmd/kubectl-direct_csi/cmd.go
+++ b/cmd/kubectl-direct_csi/cmd.go
@@ -19,8 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,9 +35,8 @@ var (
 )
 
 var pluginCmd = &cobra.Command{
-	Use:           filepath.Base(os.Args[0]),
+	Use:           "direct-csi",
 	Short:         "Plugin for managing Direct CSI drives and volumes",
-	Long:          os.Args[0],
 	SilenceUsage:  true,
 	SilenceErrors: false,
 	Version:       Version,


### PR DESCRIPTION
after `kubectl krew install direct-csi` we see
the following help output i.e a bit kludgy

```
kubectl direct-csi --help
/home/harsha/.krew/bin/kubectl-direct_csi

Usage:
  kubectl-direct_csi [command]
```

Expected should be just the following, this PR fixes this behavior
```
kubectl direct-csi --help
Plugin for managing Direct CSI drives and volumes

Usage:
  direct-csi [command]
```