### PR TITLE
Add `force` option while umounting on format

### DIFF
--- a/pkg/drive/utils.go
+++ b/pkg/drive/utils.go
@@ -52,6 +52,7 @@ func unmountDrive(drivePath string) error {
 	glog.V(3).Infof("unmounting drive %s", drivePath)
 	if err := sys.SafeUnmountAll(drivePath, []sys.UnmountOption{
 		sys.UnmountOptionDetach,
+		sys.UnmountOptionForce,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
To avoid lazy umounts while formatting the drives which may lead to formatting errors like "Device Busy". 