### PR TITLE
Display drive initialization errors and tag those as `Unavailable`

### DIFF
--- a/cmd/kubectl-direct_csi/drives_list.go
+++ b/cmd/kubectl-direct_csi/drives_list.go
@@ -252,6 +252,12 @@ func listDrives(ctx context.Context, args []string) error {
 		dr := func(val string) string {
 			dr := driveName(val)
 			for _, c := range d.Status.Conditions {
+				if c.Type == string(directv1alpha1.DirectCSIDriveConditionDiscovered) {
+					if c.Status != metav1.ConditionTrue {
+						msg = c.Reason
+						continue
+					}
+				}
 				if c.Type == string(directv1alpha1.DirectCSIDriveConditionOwned) {
 					if c.Status != metav1.ConditionTrue {
 						msg = c.Message

--- a/cmd/kubectl-direct_csi/drives_list.go
+++ b/cmd/kubectl-direct_csi/drives_list.go
@@ -252,7 +252,7 @@ func listDrives(ctx context.Context, args []string) error {
 		dr := func(val string) string {
 			dr := driveName(val)
 			for _, c := range d.Status.Conditions {
-				if c.Type == string(directv1alpha1.DirectCSIDriveConditionDiscovered) {
+				if c.Type == string(directv1alpha1.DirectCSIDriveConditionInitialized) {
 					if c.Status != metav1.ConditionTrue {
 						msg = c.Reason
 						continue

--- a/pkg/apis/direct.csi.min.io/v1alpha1/types.go
+++ b/pkg/apis/direct.csi.min.io/v1alpha1/types.go
@@ -96,17 +96,18 @@ type DirectCSIDriveStatus struct {
 type DirectCSIDriveCondition string
 
 const (
-	DirectCSIDriveConditionOwned      DirectCSIDriveCondition = "Owned"
-	DirectCSIDriveConditionMounted                            = "Mounted"
-	DirectCSIDriveConditionFormatted                          = "Formatted"
-	DirectCSIDriveConditionDiscovered                         = "Discovered"
+	DirectCSIDriveConditionOwned       DirectCSIDriveCondition = "Owned"
+	DirectCSIDriveConditionMounted                             = "Mounted"
+	DirectCSIDriveConditionFormatted                           = "Formatted"
+	DirectCSIDriveConditionInitialized                         = "Initialized"
 )
 
 type DirectCSIDriveReason string
 
 const (
-	DirectCSIDriveReasonNotAdded DirectCSIDriveReason = "NotAdded"
-	DirectCSIDriveReasonAdded                         = "Added"
+	DirectCSIDriveReasonNotAdded    DirectCSIDriveReason = "NotAdded"
+	DirectCSIDriveReasonAdded                            = "Added"
+	DirectCSIDriveReasonInitialized                      = "Initialized"
 )
 
 type RequestedFormat struct {

--- a/pkg/apis/direct.csi.min.io/v1alpha1/types.go
+++ b/pkg/apis/direct.csi.min.io/v1alpha1/types.go
@@ -96,9 +96,10 @@ type DirectCSIDriveStatus struct {
 type DirectCSIDriveCondition string
 
 const (
-	DirectCSIDriveConditionOwned     DirectCSIDriveCondition = "Owned"
-	DirectCSIDriveConditionMounted                           = "Mounted"
-	DirectCSIDriveConditionFormatted                         = "Formatted"
+	DirectCSIDriveConditionOwned      DirectCSIDriveCondition = "Owned"
+	DirectCSIDriveConditionMounted                            = "Mounted"
+	DirectCSIDriveConditionFormatted                          = "Formatted"
+	DirectCSIDriveConditionDiscovered                         = "Discovered"
 )
 
 type DirectCSIDriveReason string

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
@@ -146,6 +147,218 @@ func TestGetLatestStatus(t1 *testing.T) {
 			resStatus := GetLatestStatus(tt.reqStatusList)
 			if !reflect.DeepEqual(resStatus, tt.selectedStatus) {
 				t1.Errorf("Test case name %s: Expected status option = %v, got %v", tt.name, tt.selectedStatus, resStatus)
+			}
+		})
+	}
+
+}
+
+func TestCheckStatusEquality(t2 *testing.T) {
+	testCases := []struct {
+		name           string
+		conditionList1 []metav1.Condition
+		conditionList2 []metav1.Condition
+		expectedResult bool
+	}{
+		{
+			name: "Test1",
+			conditionList1: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			conditionList2: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Test2",
+			conditionList1: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			conditionList2: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Test3",
+			conditionList1: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			conditionList2: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Test4",
+			conditionList1: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			conditionList2: []metav1.Condition{
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionOwned),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionMounted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionFormatted),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t2.Run(tt.name, func(t2 *testing.T) {
+			result := CheckStatusEquality(tt.conditionList1, tt.conditionList2)
+			if result != tt.expectedResult {
+				t2.Errorf("Test case name %s: Expected result = %v, got %v", tt.name, tt.expectedResult, result)
 			}
 		})
 	}

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -155,9 +155,26 @@ func UpdateDriveStatusOnDiff(newObj directv1alpha1.DirectCSIDrive, existingObj *
 		existingObj.Status.Topology = newObj.Status.Topology
 		isUpdated = true
 	}
+
+	if !CheckStatusEquality(existingObj.Status.Conditions, newObj.Status.Conditions) {
+		existingObj.Status.Conditions = newObj.Status.Conditions
+		isUpdated = true
+	}
 	// Add new status canditates here
 
 	return isUpdated
+}
+
+func CheckStatusEquality(existingConditions, newConditions []metav1.Condition) bool {
+	extractStatuses := func(conds []metav1.Condition) []metav1.ConditionStatus {
+		condStatuses := []metav1.ConditionStatus{}
+		for _, cond := range conds {
+			condStatuses = append(condStatuses, cond.Status)
+		}
+		return condStatuses
+	}
+
+	return reflect.DeepEqual(extractStatuses(existingConditions), extractStatuses(newConditions))
 }
 
 // Idempotent function to bind mount a xfs filesystem with limits

--- a/pkg/sys/types.go
+++ b/pkg/sys/types.go
@@ -17,19 +17,19 @@
 package sys
 
 type BlockDevice struct {
-	Major               uint32      `json:"major"`
-	Minor               uint32      `json:"minor"`
-	Devname             string      `json:"devName,omitempty"`
-	Devtype             string      `json:"devType,omitempty"`
-	Partitions          []Partition `json:"partitions,omitempty"`
-	BlockDiscoveryError string      `json:"errString"`
+	Major                    uint32      `json:"major"`
+	Minor                    uint32      `json:"minor"`
+	Devname                  string      `json:"devName,omitempty"`
+	Devtype                  string      `json:"devType,omitempty"`
+	Partitions               []Partition `json:"partitions,omitempty"`
+	BlockInitializationError string      `json:"blockInitializationError"`
 
 	*DriveInfo `json:"driveInfo,omitempty"`
 }
 
 func (b *BlockDevice) TagError(err error) {
 	if err != nil {
-		b.BlockDiscoveryError = err.Error()
+		b.BlockInitializationError = err.Error()
 	}
 	return
 }

--- a/pkg/sys/types.go
+++ b/pkg/sys/types.go
@@ -17,13 +17,21 @@
 package sys
 
 type BlockDevice struct {
-	Major      uint32      `json:"major"`
-	Minor      uint32      `json:"minor"`
-	Devname    string      `json:"devName,omitempty"`
-	Devtype    string      `json:"devType,omitempty"`
-	Partitions []Partition `json:"partitions,omitempty"`
+	Major               uint32      `json:"major"`
+	Minor               uint32      `json:"minor"`
+	Devname             string      `json:"devName,omitempty"`
+	Devtype             string      `json:"devType,omitempty"`
+	Partitions          []Partition `json:"partitions,omitempty"`
+	BlockDiscoveryError string      `json:"errString"`
 
 	*DriveInfo `json:"driveInfo,omitempty"`
+}
+
+func (b *BlockDevice) TagError(err error) {
+	if err != nil {
+		b.BlockDiscoveryError = err.Error()
+	}
+	return
 }
 
 type Partition struct {


### PR DESCRIPTION
- Do not fail if the device discovery failed for few devices
- Communicate the discovery error in `drives ls` output

Changes made 
- Add a status condition to DirectCSIDrive - `Initialized` and record the error messages there
- Use this specific status condition while listing drives
- Add a condition to update the drive on restarts when there is a diff in the condition statuses.