### PR TITLE
Add a 'dry-run' flag to the plugin

### DIFF
--- a/cmd/kubectl-direct_csi/cmd.go
+++ b/cmd/kubectl-direct_csi/cmd.go
@@ -30,8 +30,10 @@ var Version string
 
 // flags
 var (
-	kubeconfig = ""
-	identity   = "direct.csi.min.io"
+	kubeconfig     = ""
+	identity       = "direct.csi.min.io"
+	dryRun         = false
+	dryRunFlagName = "dry-run"
 )
 
 var pluginCmd = &cobra.Command{
@@ -54,6 +56,7 @@ func init() {
 	flag.Set("logtostderr", "true")
 
 	pluginCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "k", kubeconfig, "path to kubeconfig")
+	pluginCmd.PersistentFlags().BoolVarP(&dryRun, dryRunFlagName, "", dryRun, "prints the installation yaml")
 
 	pluginCmd.PersistentFlags().MarkHidden("alsologtostderr")
 	pluginCmd.PersistentFlags().MarkHidden("log_backtrace_at")

--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -41,7 +42,6 @@ var (
 	installCRD       = false
 	overwriteCRD     = false
 	admissionControl = false
-	dryRun           = false
 	image            = "minio/direct-csi:" + Version
 )
 
@@ -50,11 +50,14 @@ func init() {
 	installCmd.PersistentFlags().BoolVarP(&overwriteCRD, "force", "f", overwriteCRD, "delete and recreate CRDs")
 	installCmd.PersistentFlags().StringVarP(&image, "image", "i", image, "direct-csi image")
 	installCmd.PersistentFlags().BoolVarP(&admissionControl, "admission-control", "", admissionControl, "turn on direct-csi admission controller")
-	installCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "", dryRun, "prints the installation yaml")
+
 }
 
 func install(ctx context.Context, args []string) error {
-	utils.Init()
+	dryRun := viper.GetBool(dryRunFlagName)
+	if !dryRun {
+		utils.Init()
+	}
 
 	if installCRD {
 	crdInstall:

--- a/cmd/kubectl-direct_csi/register.go
+++ b/cmd/kubectl-direct_csi/register.go
@@ -47,7 +47,9 @@ func registerCRDs(ctx context.Context) error {
 	crdClient := utils.GetAPIExtensionsClient()
 	for _, crd := range crdObjs {
 		if dryRun {
-			utils.LogYAML(crd)
+			if err := utils.LogYAML(crd); err != nil {
+				return err
+			}
 			continue
 		}
 		res := &apiextensions.CustomResourceDefinition{}

--- a/cmd/kubectl-direct_csi/register.go
+++ b/cmd/kubectl-direct_csi/register.go
@@ -46,6 +46,10 @@ func registerCRDs(ctx context.Context) error {
 
 	crdClient := utils.GetAPIExtensionsClient()
 	for _, crd := range crdObjs {
+		if dryRun {
+			utils.LogYAML(crd)
+			continue
+		}
 		res := &apiextensions.CustomResourceDefinition{}
 		if err := crdClient.RESTClient().
 			Post().

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/minio/direct-csi/pkg/utils"
 	"github.com/minio/direct-csi/pkg/utils/installer"
@@ -57,6 +58,13 @@ func init() {
 }
 
 func uninstall(ctx context.Context, args []string) error {
+
+	dryRun := viper.GetBool(dryRunFlagName)
+	if dryRun {
+		glog.Infof("'%s' flag is not supported for uninstall", bold(dryRunFlagName))
+		return nil
+	}
+
 	utils.Init()
 	bold := color.New(color.Bold).SprintFunc()
 	directCSIClient := utils.GetDirectCSIClient()

--- a/pkg/utils/installer/install.go
+++ b/pkg/utils/installer/install.go
@@ -125,7 +125,7 @@ func objMeta(name string) metav1.ObjectMeta {
 
 }
 
-func CreateNamespace(ctx context.Context, identity string) error {
+func CreateNamespace(ctx context.Context, identity string, dryRun bool) error {
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",
@@ -138,6 +138,10 @@ func CreateNamespace(ctx context.Context, identity string) error {
 		Status: corev1.NamespaceStatus{},
 	}
 
+	if dryRun {
+		return utils.LogYAML(ns)
+	}
+
 	// Create Namespace Obj
 	if _, err := utils.GetKubeClient().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		return err
@@ -145,7 +149,7 @@ func CreateNamespace(ctx context.Context, identity string) error {
 	return nil
 }
 
-func CreateCSIDriver(ctx context.Context, identity string) error {
+func CreateCSIDriver(ctx context.Context, identity string, dryRun bool) error {
 	podInfoOnMount := true
 	attachRequired := false
 
@@ -172,6 +176,10 @@ func CreateCSIDriver(ctx context.Context, identity string) error {
 			},
 		}
 
+		if dryRun {
+			return utils.LogYAML(csiDriver)
+		}
+
 		// Create CSIDriver Obj
 		if _, err := utils.GetKubeClient().StorageV1().CSIDrivers().Create(ctx, csiDriver, metav1.CreateOptions{}); err != nil {
 			return err
@@ -193,6 +201,10 @@ func CreateCSIDriver(ctx context.Context, identity string) error {
 			},
 		}
 
+		if dryRun {
+			return utils.LogYAML(csiDriver)
+		}
+
 		// Create CSIDriver Obj
 		if _, err := utils.GetKubeClient().StorageV1beta1().CSIDrivers().Create(ctx, csiDriver, metav1.CreateOptions{}); err != nil {
 			return err
@@ -203,7 +215,7 @@ func CreateCSIDriver(ctx context.Context, identity string) error {
 	return nil
 }
 
-func CreateStorageClass(ctx context.Context, identity string) error {
+func CreateStorageClass(ctx context.Context, identity string, dryRun bool) error {
 	allowExpansion := false
 	allowedTopologies := []corev1.TopologySelectorTerm{}
 	retainPolicy := corev1.PersistentVolumeReclaimDelete
@@ -233,6 +245,10 @@ func CreateStorageClass(ctx context.Context, identity string) error {
 			},
 		}
 
+		if dryRun {
+			return utils.LogYAML(storageClass)
+		}
+
 		if _, err := utils.GetKubeClient().StorageV1().StorageClasses().Create(ctx, storageClass, metav1.CreateOptions{}); err != nil {
 			return err
 		}
@@ -255,6 +271,10 @@ func CreateStorageClass(ctx context.Context, identity string) error {
 			},
 		}
 
+		if dryRun {
+			return utils.LogYAML(storageClass)
+		}
+
 		if _, err := utils.GetKubeClient().StorageV1beta1().StorageClasses().Create(ctx, storageClass, metav1.CreateOptions{}); err != nil {
 			return err
 		}
@@ -264,7 +284,7 @@ func CreateStorageClass(ctx context.Context, identity string) error {
 	return nil
 }
 
-func CreateService(ctx context.Context, identity string) error {
+func CreateService(ctx context.Context, identity string, dryRun bool) error {
 	csiPort := corev1.ServicePort{
 		Port: 12345,
 		Name: "unused",
@@ -284,13 +304,17 @@ func CreateService(ctx context.Context, identity string) error {
 		},
 	}
 
+	if dryRun {
+		return utils.LogYAML(svc)
+	}
+
 	if _, err := utils.GetKubeClient().CoreV1().Services(sanitizeName(identity)).Create(ctx, svc, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func CreateDaemonSet(ctx context.Context, identity string, directCSIContainerImage string) error {
+func CreateDaemonSet(ctx context.Context, identity string, directCSIContainerImage string, dryRun bool) error {
 	name := sanitizeName(identity)
 	generatedSelectorValue := generateSanitizedUniqueNameFrom(name)
 
@@ -433,13 +457,18 @@ func CreateDaemonSet(ctx context.Context, identity string, directCSIContainerIma
 		},
 		Status: appsv1.DaemonSetStatus{},
 	}
+
+	if dryRun {
+		return utils.LogYAML(daemonset)
+	}
+
 	if _, err := utils.GetKubeClient().AppsV1().DaemonSets(sanitizeName(identity)).Create(ctx, daemonset, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func CreateControllerService(ctx context.Context, generatedSelectorValue, identity string) error {
+func CreateControllerService(ctx context.Context, generatedSelectorValue, identity string, dryRun bool) error {
 	admissionWebhookPort := corev1.ServicePort{
 		Port: admissionControllerWebhookPort,
 		TargetPort: intstr.IntOrString{
@@ -464,13 +493,17 @@ func CreateControllerService(ctx context.Context, generatedSelectorValue, identi
 		},
 	}
 
+	if dryRun {
+		return utils.LogYAML(svc)
+	}
+
 	if _, err := utils.GetKubeClient().CoreV1().Services(sanitizeName(identity)).Create(ctx, svc, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func CreateControllerSecret(ctx context.Context, identity string, publicCertBytes, privateKeyBytes []byte) error {
+func CreateControllerSecret(ctx context.Context, identity string, publicCertBytes, privateKeyBytes []byte, dryRun bool) error {
 
 	getCertsDataMap := func() map[string][]byte {
 		mp := make(map[string][]byte)
@@ -491,13 +524,17 @@ func CreateControllerSecret(ctx context.Context, identity string, publicCertByte
 		Data: getCertsDataMap(),
 	}
 
+	if dryRun {
+		return utils.LogYAML(secret)
+	}
+
 	if _, err := utils.GetKubeClient().CoreV1().Secrets(sanitizeName(identity)).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func CreateDeployment(ctx context.Context, identity string, directCSIContainerImage string) error {
+func CreateDeployment(ctx context.Context, identity string, directCSIContainerImage string, dryRun bool) error {
 	name := sanitizeName(identity)
 	generatedSelectorValue := generateSanitizedUniqueNameFrom(name)
 
@@ -603,7 +640,7 @@ func CreateDeployment(ctx context.Context, identity string, directCSIContainerIm
 	}
 	caBundle = caCertBytes
 
-	if err := CreateControllerSecret(ctx, identity, publicCertBytes, privateKeyBytes); err != nil {
+	if err := CreateControllerSecret(ctx, identity, publicCertBytes, privateKeyBytes, dryRun); err != nil {
 		if !kerr.IsAlreadyExists(err) {
 			return err
 		}
@@ -638,11 +675,15 @@ func CreateDeployment(ctx context.Context, identity string, directCSIContainerIm
 		sanitizeName(identity) + DirectCSIFinalizerDeleteProtection,
 	}
 
+	if dryRun {
+		return utils.LogYAML(deployment)
+	}
+
 	if _, err := utils.GetKubeClient().AppsV1().Deployments(sanitizeName(identity)).Create(ctx, deployment, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
-	if err := CreateControllerService(ctx, generatedSelectorValue, identity); err != nil {
+	if err := CreateControllerService(ctx, generatedSelectorValue, identity, dryRun); err != nil {
 		return err
 	}
 
@@ -782,8 +823,12 @@ func getDriveValidatingWebhookConfig(identity string) admissionv1.ValidatingWebh
 	return validatingWebhookConfiguration
 }
 
-func RegisterDriveValidationRules(ctx context.Context, identity string) error {
+func RegisterDriveValidationRules(ctx context.Context, identity string, dryRun bool) error {
 	driveValidatingWebhookConfig := getDriveValidatingWebhookConfig(identity)
+	if dryRun {
+		return utils.LogYAML(driveValidatingWebhookConfig)
+	}
+
 	if _, err := utils.GetKubeClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, &driveValidatingWebhookConfig, metav1.CreateOptions{}); err != nil {
 		return err
 	}

--- a/pkg/utils/installer/install.go
+++ b/pkg/utils/installer/install.go
@@ -153,12 +153,16 @@ func CreateCSIDriver(ctx context.Context, identity string, dryRun bool) error {
 	podInfoOnMount := true
 	attachRequired := false
 
-	gvk, err := utils.GetGroupKindVersions("storage.k8s.io", "CSIDriver", "v1", "v1beta1", "v1alpha1")
-	if err != nil {
-		return err
+	version := "v1"
+	if !dryRun {
+		gvk, err := utils.GetGroupKindVersions("storage.k8s.io", "CSIDriver", "v1", "v1beta1", "v1alpha1")
+		if err != nil {
+			return err
+		}
+		version = gvk.Version
 	}
 
-	switch gvk.Version {
+	switch version {
 	case "v1":
 		csiDriver := &storagev1.CSIDriver{
 			TypeMeta: metav1.TypeMeta{
@@ -220,12 +224,16 @@ func CreateStorageClass(ctx context.Context, identity string, dryRun bool) error
 	allowedTopologies := []corev1.TopologySelectorTerm{}
 	retainPolicy := corev1.PersistentVolumeReclaimDelete
 
-	gvk, err := utils.GetGroupKindVersions("storage.k8s.io", "CSIDriver", "v1", "v1beta1", "v1alpha1")
-	if err != nil {
-		return err
+	version := "v1"
+	if !dryRun {
+		gvk, err := utils.GetGroupKindVersions("storage.k8s.io", "CSIDriver", "v1", "v1beta1", "v1alpha1")
+		if err != nil {
+			return err
+		}
+		version = gvk.Version
 	}
 
-	switch gvk.Version {
+	switch version {
 	case "v1":
 		bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 		// Create StorageClass for the new driver

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,7 +5,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/yaml"
+
 	"github.com/golang/glog"
+
+	"fmt"
 )
 
 func JSONifyAndLog(val interface{}) {
@@ -21,4 +25,20 @@ func BoolToCondition(val bool) metav1.ConditionStatus {
 		return metav1.ConditionTrue
 	}
 	return metav1.ConditionFalse
+}
+
+func LogYAML(obj interface{}) error {
+	y, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	PrintYaml(y)
+	return nil
+}
+
+func PrintYaml(data []byte) {
+	fmt.Print(string(data))
+	fmt.Println()
+	fmt.Println("---")
+	fmt.Println()
 }


### PR DESCRIPTION
- Add a persistent flag - `dry-run` to the plugin, Which prints the yaml instead of applying it to the cluster
- `dry-run` flag will be effective for `format` and `install` commands