### PR TITLE
Fix block device error tagging

### DIFF
--- a/cmd/kubectl-direct_csi/drives_list.go
+++ b/cmd/kubectl-direct_csi/drives_list.go
@@ -254,13 +254,14 @@ func listDrives(ctx context.Context, args []string) error {
 			for _, c := range d.Status.Conditions {
 				if c.Type == string(directv1alpha1.DirectCSIDriveConditionInitialized) {
 					if c.Status != metav1.ConditionTrue {
-						msg = c.Reason
+						msg = c.Message
 						continue
 					}
 				}
 				if c.Type == string(directv1alpha1.DirectCSIDriveConditionOwned) {
 					if c.Status != metav1.ConditionTrue {
 						msg = c.Message
+						continue
 					}
 				}
 			}

--- a/pkg/node/discovery.go
+++ b/pkg/node/discovery.go
@@ -153,15 +153,15 @@ func makePartitionDrive(nodeID string, partition sys.Partition, rootPartition, b
 					LastTransitionTime: metav1.Now(),
 				},
 				{
-					Type:    string(directv1alpha1.DirectCSIDriveConditionInitialized),
-					Status:  blockInitializationStatus,
-					Message: "DriveInitialized",
-					Reason: func() string {
+					Type:   string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status: blockInitializationStatus,
+					Message: func() string {
 						if blockErrString == "" {
 							return directv1alpha1.DirectCSIDriveReasonInitialized
 						}
 						return blockErrString
 					}(),
+					Reason:             string(directv1alpha1.DirectCSIDriveReasonInitialized),
 					LastTransitionTime: metav1.Now(),
 				},
 			},
@@ -256,15 +256,15 @@ func makeRootDrive(nodeID string, blockDevice sys.BlockDevice) (*directv1alpha1.
 					LastTransitionTime: metav1.Now(),
 				},
 				{
-					Type:    string(directv1alpha1.DirectCSIDriveConditionInitialized),
-					Status:  blockInitializationStatus,
-					Message: "DriveInitialized",
-					Reason: func() string {
+					Type:   string(directv1alpha1.DirectCSIDriveConditionInitialized),
+					Status: blockInitializationStatus,
+					Message: func() string {
 						if blockDevice.BlockInitializationError == "" {
 							return directv1alpha1.DirectCSIDriveReasonInitialized
 						}
 						return blockDevice.BlockInitializationError
 					}(),
+					Reason:             string(directv1alpha1.DirectCSIDriveReasonInitialized),
 					LastTransitionTime: metav1.Now(),
 				},
 			},


### PR DESCRIPTION
Attach the error message to condition.Message instead of conditon.Reason