### PR TITLE
Remove unnecessary 'return' while probing block device

### DIFF
--- a/pkg/sys/drive_discovery_linux.go
+++ b/pkg/sys/drive_discovery_linux.go
@@ -77,7 +77,6 @@ func (b *BlockDevice) probeBlockDev(ctx context.Context) (err error) {
 		if err != nil {
 			b.TagError(err)
 		}
-		return
 	}()
 
 	err = os.MkdirAll(DirectCSIDevRoot, 0755)


### PR DESCRIPTION
Remove explicit `return` in defer function