### PR TITLE
Fix Minor number while making direct-csi block devices partitions

### DIFF
--- a/pkg/sys/partition_discovery_linux.go
+++ b/pkg/sys/partition_discovery_linux.go
@@ -95,7 +95,7 @@ func (b *BlockDevice) probeAAPMBR(ctx context.Context) ([]Partition, error) {
 		if !p.Is() {
 			continue
 		}
-		partNum := uint32(i) + b.Minor
+		partNum := uint32(i+1) + b.Minor
 		partitionPath := fmt.Sprintf("%s-part-%d", b.Path, i+1)
 		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
 			return nil, err
@@ -145,7 +145,7 @@ func (b *BlockDevice) probeClassicMBR(ctx context.Context) ([]Partition, error) 
 		if !p.Is() {
 			continue
 		}
-		partNum := b.Minor + uint32(i)
+		partNum := b.Minor + uint32(i+1)
 		partitionPath := fmt.Sprintf("%s-part-%d", b.Path, i+1)
 		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
 			return nil, err
@@ -195,7 +195,7 @@ func (b *BlockDevice) probeModernStandardMBR(ctx context.Context) ([]Partition, 
 		if !p.Is() {
 			continue
 		}
-		partNum := b.Minor + uint32(i)
+		partNum := b.Minor + uint32(i+1)
 		partitionPath := fmt.Sprintf("%s-part-%d", b.Path, i+1)
 		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
 			return nil, err
@@ -279,7 +279,7 @@ func (b *BlockDevice) probeGPT(ctx context.Context) ([]Partition, error) {
 			partType = partTypeUUID
 		}
 
-		partNum := b.Minor + uint32(i)
+		partNum := b.Minor + uint32(i+1)
 		partitionPath := fmt.Sprintf("%s-part-%d", b.Path, i+1)
 		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
 			return nil, err


### PR DESCRIPTION
The minor numbers were not matching when creating block devices

**Without the fix** 

```
ubuntu@directcsi-1:~$ ls -l /dev/xvd*
brw-rw---- 1 root disk 202,  0 Feb  1 04:57 /dev/xvda
brw-rw---- 1 root disk 202,  1 Feb  1 04:57 /dev/xvda1
brw-rw---- 1 root disk 202, 16 Feb  1 04:58 /dev/xvdb
brw-rw---- 1 root disk 202, 17 Feb  1 04:58 /dev/xvdb1
brw-rw---- 1 root disk 202, 18 Feb  1 04:58 /dev/xvdb2
brw-rw---- 1 root disk 202, 32 Feb  1 04:57 /dev/xvdc
ubuntu@directcsi-1:~$ ls -l /var/lib/direct-csi/devices/
total 0
brw-r--r-- 1 root root 202,  0 Feb  9 13:39 xvda
brw-r--r-- 1 root root 202,  0 Feb  9 13:39 xvda-part-1
brw-r--r-- 1 root root 202, 16 Feb  9 13:39 xvdb
brw-r--r-- 1 root root 202, 16 Feb  9 13:39 xvdb-part-1
brw-r--r-- 1 root root 202, 17 Feb  9 13:39 xvdb-part-2
brw-r--r-- 1 root root 202, 32 Feb  9 13:39 xvdc
```

**With the fix** 

```
ubuntu@directcsi-1:~$ ls -l /dev/xvd*
brw-rw---- 1 root disk 202,  0 Feb  1 04:57 /dev/xvda
brw-rw---- 1 root disk 202,  1 Feb  1 04:57 /dev/xvda1
brw-rw---- 1 root disk 202, 16 Feb  1 04:58 /dev/xvdb
brw-rw---- 1 root disk 202, 17 Feb  1 04:58 /dev/xvdb1
brw-rw---- 1 root disk 202, 18 Feb  1 04:58 /dev/xvdb2
brw-rw---- 1 root disk 202, 32 Feb  1 04:57 /dev/xvdc
ubuntu@directcsi-1:~$ ls -l /var/lib/direct-csi/devices/
total 0
brw-r--r-- 1 root root 202,  0 Feb  9 14:11 xvda
brw-r--r-- 1 root root 202,  1 Feb  9 14:11 xvda-part-1
brw-r--r-- 1 root root 202, 16 Feb  9 14:11 xvdb
brw-r--r-- 1 root root 202, 17 Feb  9 14:11 xvdb-part-1
brw-r--r-- 1 root root 202, 18 Feb  9 14:11 xvdb-part-2
brw-r--r-- 1 root root 202, 32 Feb  9 14:11 xvdc
```