### PR TITLE
Fix umounting the drives by source path

### DIFF
--- a/cmd/kubectl-direct_csi/drives_list.go
+++ b/cmd/kubectl-direct_csi/drives_list.go
@@ -69,6 +69,10 @@ var (
 	all = false
 )
 
+const (
+	directCSIPartitionInfix = "-part-"
+)
+
 func init() {
 	listDrivesCmd.PersistentFlags().StringSliceVarP(&drives, "drives", "d", drives, "glob prefix match for drive paths")
 	listDrivesCmd.PersistentFlags().StringSliceVarP(&nodes, "nodes", "n", nodes, "glob prefix match for node names")
@@ -142,7 +146,7 @@ func listDrives(ctx context.Context, args []string) error {
 	for _, d := range filterNodes {
 		for _, n := range drivesList {
 			pathTransform := func(in string) string {
-				path := strings.ReplaceAll(in, "-part-", "")
+				path := strings.ReplaceAll(in, directCSIPartitionInfix, "")
 				path = strings.ReplaceAll(path, sys.DirectCSIDevRoot+"/", "")
 				path = strings.ReplaceAll(path, sys.HostDevRoot+"/", "")
 				return filepath.Base(path)
@@ -237,7 +241,7 @@ func listDrives(ctx context.Context, args []string) error {
 	driveName := func(val string) string {
 		dr := strings.ReplaceAll(val, sys.DirectCSIDevRoot+"/", "")
 		dr = strings.ReplaceAll(dr, sys.HostDevRoot+"/", "")
-		return strings.ReplaceAll(dr, "-part-", "")
+		return strings.ReplaceAll(dr, directCSIPartitionInfix, "")
 	}
 
 	for _, d := range filterStatus {
@@ -265,13 +269,14 @@ func listDrives(ctx context.Context, args []string) error {
 					}
 				}
 			}
-			return strings.ReplaceAll("/dev/"+dr, "-part-", "")
+			return strings.ReplaceAll("/dev/"+dr, directCSIPartitionInfix, "")
 		}(d.Status.Path)
 		drStatus := d.Status.DriveStatus
 		if msg != "" {
 			drStatus = drStatus + "*"
 			msg = strings.ReplaceAll(msg, d.Name, "")
 			msg = strings.ReplaceAll(msg, "/var/lib/direct-csi/devices", "/dev")
+			msg = strings.ReplaceAll(msg, directCSIPartitionInfix, "")
 			msg = strings.Split(msg, "\n")[0]
 		}
 

--- a/pkg/sys/mount_linux.go
+++ b/pkg/sys/mount_linux.go
@@ -244,7 +244,7 @@ func SafeUnmountAll(drivePath string, opts []UnmountOption) error {
 	}
 
 	for _, m := range mounts {
-		if getBlockFile(m.DevName) == getBlockFile(drivePath) {
+		if getBlockFile(m.MountSource) == getBlockFile(drivePath) {
 			if err := SafeUnmount(m.Mountpoint, opts); err != nil {
 				return err
 			}

--- a/pkg/sys/sys_test.go
+++ b/pkg/sys/sys_test.go
@@ -1,0 +1,111 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sys
+
+import (
+	"testing"
+)
+
+func TestGetBlockFile(t1 *testing.T) {
+
+	testCases := []struct {
+		name      string
+		devName   string
+		blockFile string
+	}{
+		{
+			name:      "test1",
+			devName:   "/var/lib/direct-csi/devices/xvdb",
+			blockFile: "/var/lib/direct-csi/devices/xvdb",
+		},
+		{
+			name:      "test2",
+			devName:   "/var/lib/direct-csi/devices/xvdb-part-1",
+			blockFile: "/var/lib/direct-csi/devices/xvdb-part-1",
+		},
+		{
+			name:      "test3",
+			devName:   "/dev/xvdb",
+			blockFile: "/var/lib/direct-csi/devices/xvdb",
+		},
+		{
+			name:      "test4",
+			devName:   "/dev/xvdb3",
+			blockFile: "/var/lib/direct-csi/devices/xvdb-part-3",
+		},
+		{
+			name:      "test5",
+			devName:   "/dev/xvdb15",
+			blockFile: "/var/lib/direct-csi/devices/xvdb-part-15",
+		},
+	}
+
+	for _, tt := range testCases {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			blockFile := getBlockFile(tt.devName)
+			if blockFile != tt.blockFile {
+				t1.Errorf("Test case name %s: Expected block file = (%s) got: %s", tt.name, tt.blockFile, blockFile)
+			}
+		})
+	}
+
+}
+
+func TestGetRootBlockFile(t1 *testing.T) {
+
+	testCases := []struct {
+		name     string
+		devName  string
+		rootFile string
+	}{
+		{
+			name:     "test1",
+			devName:  "/dev/xvdb",
+			rootFile: "/dev/xvdb",
+		},
+		{
+			name:     "test2",
+			devName:  "/dev/xvdb1",
+			rootFile: "/dev/xvdb1",
+		},
+		{
+			name:     "test3",
+			devName:  "/var/lib/direct-csi/devices/xvdb",
+			rootFile: "/dev/xvdb",
+		},
+		{
+			name:     "test4",
+			devName:  "/var/lib/direct-csi/devices/xvdb-part-3",
+			rootFile: "/dev/xvdb3",
+		},
+		{
+			name:     "test5",
+			devName:  "/var/lib/direct-csi/devices/xvdb-part-15",
+			rootFile: "/dev/xvdb15",
+		},
+	}
+
+	for _, tt := range testCases {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			rootFile := getRootBlockFile(tt.devName)
+			if rootFile != tt.rootFile {
+				t1.Errorf("Test case name %s: Expected root file = (%s) got: %s", tt.name, tt.rootFile, rootFile)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
- Fix the getBlockFile util to return correct value for partitions

Eg, `/dev/xvdb1` should return `/var/lib/direct-csi/devices/xvdb-part-1`
     instead of `/var/lib/direct-csi/devices/xvdb1`

- Also, Fix the getRootBlockFile to cover the following case

  `/var/lib/direct-csi/devices/xvdb-part-1` should return `/dev/xvdb1`
  instead of `/dev/xvdb-part-1`

- Add unit test cases for these functions