### PR TITLE
Fix ProbeMountInfo() to return correct device names

### DIFF
--- a/pkg/sys/sys_test.go
+++ b/pkg/sys/sys_test.go
@@ -129,3 +129,54 @@ func TestGetRootBlockFile(t1 *testing.T) {
 	}
 
 }
+
+func TestSplitDevAndPartNum(t1 *testing.T) {
+
+	testCases := []struct {
+		name     string
+		inputStr string
+		devName  string
+		partNum  int
+	}{
+		{
+			name:     "test1",
+			inputStr: "/var/lib/direct-csi/devices/xvdb-part-11",
+			devName:  "/var/lib/direct-csi/devices/xvdb",
+			partNum:  11,
+		},
+		{
+			name:     "test2",
+			inputStr: "/var/lib/direct-csi/devices/xvdb",
+			devName:  "/var/lib/direct-csi/devices/xvdb",
+			partNum:  0,
+		},
+		{
+			name:     "test3",
+			inputStr: "/var/lib/direct-csi/devices/nvmen1p-part-13",
+			devName:  "/var/lib/direct-csi/devices/nvmen1p",
+			partNum:  13,
+		},
+		{
+			name:     "test4",
+			inputStr: "/dev/sdb1",
+			devName:  "/dev/sdb",
+			partNum:  1,
+		},
+		{
+			name:     "test5",
+			inputStr: "/dev/sdb1",
+			devName:  "/dev/sdb",
+			partNum:  1,
+		},
+	}
+
+	for _, tt := range testCases {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			dName, partNum := splitDevAndPartNum(tt.inputStr)
+			if dName != tt.devName || partNum != tt.partNum {
+				t1.Errorf("Test case name %s: Expected (devName, partNum) = (%s, %d) got: (%s, %d)", tt.name, tt.devName, tt.partNum, dName, partNum)
+			}
+		})
+	}
+
+}

--- a/pkg/sys/sys_utils.go
+++ b/pkg/sys/sys_utils.go
@@ -67,6 +67,13 @@ func splitDevAndPartNum(s string) (string, int) {
 	possibleNum := strings.Builder{}
 	toRet := strings.Builder{}
 
+	cleanPartitionInfix := func(str string) string {
+		if strings.HasSuffix(str, directCSIPartitionInfix) {
+			return str[:len(str)-len(directCSIPartitionInfix)]
+		}
+		return str
+	}
+
 	//finds number at the end of a string
 	for _, r := range s {
 		if r >= '0' && r <= '9' {
@@ -83,9 +90,9 @@ func splitDevAndPartNum(s string) (string, int) {
 		numVal, err := strconv.Atoi(num)
 		if err != nil {
 			// return full input string in this case
-			return s, 0
+			return cleanPartitionInfix(s), 0
 		}
-		return str, numVal
+		return cleanPartitionInfix(str), numVal
 	}
 	return str, 0
 }


### PR DESCRIPTION
- The `DevName` should not have `-part-` infix
- Add test cases for coverage

Steps to test :
- Mount the `/var/lib/direct-csi/devices/XX` and then restart the drive discovery
- Mountpoint should be set correctly

Note: Before the fix, the DevName was showing up as `/var/lib/direct-csi/devices/xvdb-part-` instead of `/var/lib/direct-csi/devices/xvdb` on the mount discovery results