### PR TITLE
Add conversion webhook to enable CRD version migration

### DIFF
--- a/cmd/direct-csi/cmd.go
+++ b/cmd/direct-csi/cmd.go
@@ -42,6 +42,7 @@ var (
 	controller = false
 	driver     = false
 	procfs     = "/proc"
+	conversion = false
 )
 
 var driverCmd = &cobra.Command{
@@ -56,8 +57,8 @@ For more information, use '%s man [sched | examples | ...]'
 `, os.Args[0]),
 	SilenceUsage: true,
 	RunE: func(c *cobra.Command, args []string) error {
-		if !controller && !driver {
-			return fmt.Errorf("either --controller or --driver should be set")
+		if !controller && !driver && !conversion {
+			return fmt.Errorf("one among [--controller, --driver, --conversion] should be set")
 		}
 
 		return run(c.Context(), args)
@@ -86,6 +87,7 @@ func init() {
 	driverCmd.Flags().StringVarP(&procfs, "procfs", "", procfs, "path to host /proc for accessing mount information")
 	driverCmd.Flags().BoolVarP(&controller, "controller", "", controller, "running in controller mode")
 	driverCmd.Flags().BoolVarP(&driver, "driver", "", driver, "run in driver mode")
+	driverCmd.Flags().BoolVarP(&conversion, "conversion", "", conversion, "run in conversion mode")
 
 	driverCmd.PersistentFlags().MarkHidden("alsologtostderr")
 	driverCmd.PersistentFlags().MarkHidden("log_backtrace_at")

--- a/cmd/direct-csi/run.go
+++ b/cmd/direct-csi/run.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	ctrl "github.com/minio/direct-csi/pkg/controller"
+	"github.com/minio/direct-csi/pkg/converter"
 	id "github.com/minio/direct-csi/pkg/identity"
 	"github.com/minio/direct-csi/pkg/node"
 	"github.com/minio/direct-csi/pkg/utils"
@@ -32,8 +33,17 @@ import (
 )
 
 func run(ctx context.Context, args []string) error {
-	utils.Init()
 
+	if conversion {
+		// Start conversion webserver
+		if err := converter.ServeConversionWebhook(ctx); err != nil {
+			return err
+		}
+		// Do not start node server and central controller in conversion mode
+		return nil
+	}
+
+	utils.Init()
 	idServer, err := id.NewIdentityServer(identity, Version, map[string]string{})
 	if err != nil {
 		return err

--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -61,6 +61,24 @@ func install(ctx context.Context, args []string) error {
 		utils.Init()
 	}
 
+	if err := installer.CreateNamespace(ctx, identity, dryRun); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	if !dryRun {
+		glog.Infof("'%s' namespace created", utils.Bold(identity))
+	}
+
+	if err := installer.CreateConversionDeployment(ctx, identity, image, dryRun, registry); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	if !dryRun {
+		glog.Infof("'%s' conversion deployment created", utils.Bold(identity))
+	}
+
 	if installCRD {
 	crdInstall:
 		if err := registerCRDs(ctx); err != nil {
@@ -80,15 +98,6 @@ func install(ctx context.Context, args []string) error {
 		if !dryRun {
 			glog.Infof("crds successfully registered")
 		}
-	}
-
-	if err := installer.CreateNamespace(ctx, identity, dryRun); err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return err
-		}
-	}
-	if !dryRun {
-		glog.Infof("'%s' namespace created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateCSIDriver(ctx, identity, dryRun); err != nil {

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -159,18 +159,32 @@ func uninstall(ctx context.Context, args []string) error {
 		}
 	}
 
-	if err := installer.DeleteSecrets(ctx, identity); err != nil {
+	if err := installer.DeleteControllerSecret(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
 	glog.Infof("'%s' drive validation rules removed", utils.Bold(identity))
 
-	if err := installer.DeleteDeployment(ctx, identity); err != nil {
+	if err := installer.DeleteControllerDeployment(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	glog.Infof("'%s' deployment deleted", utils.Bold(identity))
+	glog.Infof("'%s' controller deployment deleted", utils.Bold(identity))
+
+	if err := installer.DeleteConversionDeployment(ctx, identity); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err := installer.DeleteConversionSecret(ctx, identity); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	glog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
+
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
 	github.com/minio/minio v0.0.0-20210110213705-828602d672f7
 	github.com/minio/sha256-simd v0.1.1
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -1,0 +1,174 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package converter
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+
+	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	versionV1Alpha1 = "direct.csi.min.io/v1alpha1"
+	versionV1Test   = "direct.csi.min.io/v1test"
+)
+
+var (
+	supportedVersions = []string{versionV1Alpha1,
+		versionV1Test} //ordered
+)
+
+type migrateFunc func(fromVersion, toVersion string, Object *unstructured.Unstructured) error
+
+func convertDriveCRD(Object *unstructured.Unstructured, toVersion string) (*unstructured.Unstructured, metav1.Status) {
+	glog.V(2).Info("converting crd")
+
+	convertedObject := Object.DeepCopy()
+	fromVersion := Object.GetAPIVersion()
+
+	migrateFn, err := getMigrateFunc(fromVersion, toVersion)
+	if err != nil {
+		return nil, statusErrorWithMessage(err.Error())
+	}
+
+	// migrate the CRDs
+	migrateFn(fromVersion, toVersion, convertedObject)
+
+	return convertedObject, statusSucceed()
+}
+
+func getMigrateFunc(fromVersion, toVersion string) (migrateFunc, error) {
+	var migrateFn migrateFunc
+	getIndex := func(version string) int {
+		for i := range supportedVersions {
+			if supportedVersions[i] == version {
+				return i
+			}
+		}
+		return -1
+	}
+
+	shouldUpgrade := func() (bool, error) {
+		fromIndex := getIndex(fromVersion)
+		if fromIndex == -1 {
+			return false, fmt.Errorf("Invalid fromVersion: %s", fromVersion)
+		}
+
+		toIndex := getIndex(toVersion)
+		if toIndex == -1 {
+			return false, fmt.Errorf("Invalid toVersion: %s", toVersion)
+		}
+
+		if fromIndex == toIndex {
+			return false, fmt.Errorf("conversion from a version to itself should not call the webhook: %s", toVersion)
+		}
+
+		if fromIndex > toIndex {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	upgrade, err := shouldUpgrade()
+	if err != nil {
+		return migrateFn, err
+	}
+
+	migrateFn = func() migrateFunc {
+		if upgrade {
+			return upgradeObject
+		}
+		return downgradeObject
+	}()
+
+	return migrateFn, nil
+}
+
+func upgradeObject(fromVersion, toVersion string, convertedObject *unstructured.Unstructured) error {
+	switch fromVersion {
+	case versionV1Alpha1:
+		if err := upgradeV1alpha1ToV1test(convertedObject); err != nil {
+			return err
+		}
+		fallthrough
+	case versionV1Test:
+		if toVersion == versionV1Test {
+			glog.V(2).Info("Successfully migrated")
+			break
+		}
+	}
+	return nil
+}
+
+func upgradeV1alpha1ToV1test(unstructured *unstructured.Unstructured) error {
+
+	unstructuredObject := unstructured.Object
+
+	var directCSIDrive directv1alpha1.DirectCSIDrive
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject, &directCSIDrive)
+	if err != nil {
+		return err
+	}
+
+	directCSIDrive.Status.DriveStatus = directv1alpha1.DriveStatusUnavailable
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&directCSIDrive)
+	if err != nil {
+		return err
+	}
+
+	unstructured.Object = convertedObj
+	return nil
+}
+
+func downgradeObject(fromVersion, toVersion string, convertedObject *unstructured.Unstructured) error {
+	switch fromVersion {
+	case versionV1Test:
+		if err := downgradeV1testToV1alpha1(convertedObject); err != nil {
+			return err
+		}
+		fallthrough
+	case versionV1Alpha1:
+		if toVersion == versionV1Alpha1 {
+			glog.V(2).Info("Successfully migrated")
+			break
+		}
+	}
+	return nil
+}
+
+func downgradeV1testToV1alpha1(unstructured *unstructured.Unstructured) error {
+
+	unstructuredObject := unstructured.Object
+
+	var directCSIDrive directv1alpha1.DirectCSIDrive
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject, &directCSIDrive); err != nil {
+		return err
+	}
+
+	directCSIDrive.Status.DriveStatus = directv1alpha1.DriveStatusAvailable
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIDrive)
+	if err != nil {
+		return err
+	}
+
+	unstructured.Object = convertedObj
+	return nil
+}

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -1,0 +1,84 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package converter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+func TestConverter(t *testing.T) {
+	sampleObj := `kind: ConversionReview
+apiVersion: apiextensions.k8s.io/v1
+request:
+  uid: 0000-0000-0000-0000
+  desiredAPIVersion: direct.csi.min.io/v1test
+  objects:
+  - apiVersion: direct.csi.min.io/v1alpha1
+    kind: DirectCSIDrive
+    metadata:
+      name: name-name
+    spec:
+      directCSIOwned: true
+    status:
+      path: /dev/xvdb
+      nodeName: directcsinode-1
+      driveStatus: Available
+`
+	response := httptest.NewRecorder()
+	request, err := http.NewRequest("POST", driveHandlerPath, strings.NewReader(sampleObj))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Add("Content-Type", "application/yaml")
+	ServeConversion(response, request)
+	convertReview := v1.ConversionReview{}
+	scheme := runtime.NewScheme()
+	yamlSerializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true})
+	if _, _, err := yamlSerializer.Decode(response.Body.Bytes(), nil, &convertReview); err != nil {
+		t.Fatalf("cannot decode data: \n %v\n Error: %v", response.Body, err)
+	}
+	if convertReview.Response.Result.Status != metav1.StatusSuccess {
+		t.Fatalf("cr conversion failed: %v", convertReview.Response)
+	}
+	convertedObj := unstructured.Unstructured{}
+	if _, _, err := yamlSerializer.Decode(convertReview.Response.ConvertedObjects[0].Raw, nil, &convertedObj); err != nil {
+		t.Fatal(err)
+	}
+	if e, a := versionV1Test, convertedObj.GetAPIVersion(); e != a {
+		t.Errorf("expected= %v, actual= %v", e, a)
+	}
+
+	var directCSIDrive directv1alpha1.DirectCSIDrive
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(convertedObj.Object, &directCSIDrive); err != nil {
+		t.Errorf("Error while convertinng %v", err)
+	}
+
+	if directCSIDrive.Status.DriveStatus != directv1alpha1.DriveStatusUnavailable {
+		t.Errorf("expected status.driveStatus = %v, actual status.driveStatus = %v", directv1alpha1.DriveStatusUnavailable, directCSIDrive.Status.DriveStatus)
+	}
+
+}

--- a/pkg/converter/framework.go
+++ b/pkg/converter/framework.go
@@ -1,0 +1,178 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package converter
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/munnerz/goautoneg"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+// convertFunc is the user defined function for any conversion. The code in this file is a
+// template that can be use for any CR conversion given this function.
+type convertFunc func(Object *unstructured.Unstructured, version string) (*unstructured.Unstructured, metav1.Status)
+
+// conversionResponseFailureWithMessagef is a helper function to create an AdmissionResponse
+// with a formatted embedded error message.
+func conversionResponseFailureWithMessagef(msg string, params ...interface{}) *v1.ConversionResponse {
+	return &v1.ConversionResponse{
+		Result: metav1.Status{
+			Message: fmt.Sprintf(msg, params...),
+			Status:  metav1.StatusFailure,
+		},
+	}
+
+}
+
+func statusErrorWithMessage(msg string, params ...interface{}) metav1.Status {
+	return metav1.Status{
+		Message: fmt.Sprintf(msg, params...),
+		Status:  metav1.StatusFailure,
+	}
+}
+
+func statusSucceed() metav1.Status {
+	return metav1.Status{
+		Status: metav1.StatusSuccess,
+	}
+}
+
+// doConversion converts the requested object given the conversion function and returns a conversion response.
+// failures will be reported as Reason in the conversion response.
+func doConversion(convertRequest *v1.ConversionRequest, convert convertFunc) *v1.ConversionResponse {
+	var convertedObjects []runtime.RawExtension
+	for _, obj := range convertRequest.Objects {
+		cr := unstructured.Unstructured{}
+		if err := cr.UnmarshalJSON(obj.Raw); err != nil {
+			glog.Error(err)
+			return conversionResponseFailureWithMessagef("failed to unmarshall object (%v) with error: %v", string(obj.Raw), err)
+		}
+		convertedCR, status := convert(&cr, convertRequest.DesiredAPIVersion)
+		if status.Status != metav1.StatusSuccess {
+			glog.Error(status.String())
+			return &v1.ConversionResponse{
+				Result: status,
+			}
+		}
+		convertedCR.SetAPIVersion(convertRequest.DesiredAPIVersion)
+		convertedObjects = append(convertedObjects, runtime.RawExtension{Object: convertedCR})
+	}
+	return &v1.ConversionResponse{
+		ConvertedObjects: convertedObjects,
+		Result:           statusSucceed(),
+	}
+}
+
+func serve(w http.ResponseWriter, r *http.Request, convert convertFunc) {
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	serializer := getInputSerializer(contentType)
+	if serializer == nil {
+		msg := fmt.Sprintf("invalid Content-Type header `%s`", contentType)
+		glog.Errorf(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	glog.V(2).Infof("handling request: %v", body)
+	convertReview := v1.ConversionReview{}
+	if _, _, err := serializer.Decode(body, nil, &convertReview); err != nil {
+		glog.Error(err)
+		convertReview.Response = conversionResponseFailureWithMessagef("failed to deserialize body (%v) with error %v", string(body), err)
+	} else {
+		convertReview.Response = doConversion(convertReview.Request, convert)
+		convertReview.Response.UID = convertReview.Request.UID
+	}
+	glog.V(2).Info(fmt.Sprintf("sending response: %v", convertReview.Response))
+
+	// reset the request, it is not needed in a response.
+	convertReview.Request = &v1.ConversionRequest{}
+
+	accept := r.Header.Get("Accept")
+	outSerializer := getOutputSerializer(accept)
+	if outSerializer == nil {
+		msg := fmt.Sprintf("invalid accept header `%s`", accept)
+		glog.Errorf(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+	err := outSerializer.Encode(&convertReview, w)
+	if err != nil {
+		glog.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func ServeConversion(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, convertDriveCRD)
+}
+
+type mediaType struct {
+	Type, SubType string
+}
+
+var scheme = runtime.NewScheme()
+var serializers = map[mediaType]runtime.Serializer{
+	{"application", "json"}: json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{}),
+	{"application", "yaml"}: json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true}),
+}
+
+func getInputSerializer(contentType string) runtime.Serializer {
+	parts := strings.SplitN(contentType, "/", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	return serializers[mediaType{parts[0], parts[1]}]
+}
+
+func getOutputSerializer(accept string) runtime.Serializer {
+	if len(accept) == 0 {
+		return serializers[mediaType{"application", "json"}]
+	}
+
+	clauses := goautoneg.ParseAccept(accept)
+	for _, clause := range clauses {
+		for k, v := range serializers {
+			switch {
+			case clause.Type == k.Type && clause.SubType == k.SubType,
+				clause.Type == k.Type && clause.SubType == "*",
+				clause.Type == "*" && clause.SubType == "*":
+				return v
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/converter/webhook.go
+++ b/pkg/converter/webhook.go
@@ -1,0 +1,69 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package converter
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+const (
+	port             = "443"
+	certPath         = "/etc/certs/cert.pem"
+	keyPath          = "/etc/certs/key.pem"
+	driveHandlerPath = "/convertdrive"
+)
+
+func ServeConversionWebhook(ctx context.Context) error {
+	certs, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		glog.Errorf("Filed to load key pair: %v", err)
+		return err
+	}
+
+	// Create a secure http server
+	server := &http.Server{
+		TLSConfig: &tls.Config{
+			Certificates:       []tls.Certificate{certs},
+			InsecureSkipVerify: true,
+		},
+	}
+
+	// define http server and server handler
+	mux := http.NewServeMux()
+	mux.HandleFunc(driveHandlerPath, ServeConversion)
+	server.Handler = mux
+
+	lc := net.ListenConfig{}
+	listener, lErr := lc.Listen(ctx, "tcp", fmt.Sprintf(":%v", port))
+	if lErr != nil {
+		return lErr
+	}
+
+	glog.Infof("Starting conversion webhook server in port: %s", port)
+	if err := server.ServeTLS(listener, "", ""); err != nil {
+		glog.Errorf("Failed to listen and serve admission webhook server: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/utils/installer/uninstall.go
+++ b/pkg/utils/installer/uninstall.go
@@ -121,14 +121,22 @@ func DeleteDriveValidationRules(ctx context.Context, identity string) error {
 	return nil
 }
 
-func DeleteSecrets(ctx context.Context, identity string) error {
+func DeleteControllerSecret(ctx context.Context, identity string) error {
 	if err := utils.GetKubeClient().CoreV1().Secrets(sanitizeName(identity)).Delete(ctx, AdmissionWebhookSecretName, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func DeleteDeployment(ctx context.Context, identity string) error {
+func DeleteControllerDeployment(ctx context.Context, identity string) error {
+	return DeleteDeployment(ctx, identity, sanitizeName(identity))
+}
+
+func DeleteConversionDeployment(ctx context.Context, identity string) error {
+	return DeleteDeployment(ctx, identity, conversionWebhookName)
+}
+
+func DeleteDeployment(ctx context.Context, identity, name string) error {
 	dClient := utils.GetKubeClient().AppsV1().Deployments(sanitizeName(identity))
 
 	getDeleteProtectionFinalizer := func() string {
@@ -148,12 +156,18 @@ func DeleteDeployment(ctx context.Context, identity string) error {
 		return nil
 	}
 
-	name := sanitizeName(identity)
 	if err := clearFinalizers(name); err != nil {
 		return err
 	}
 
 	if err := dClient.Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func DeleteConversionSecret(ctx context.Context, identity string) error {
+	if err := utils.GetKubeClient().CoreV1().Secrets(sanitizeName(identity)).Delete(ctx, ConversionWebhookSecretName, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Creates a deployment for the conversion with replica count 3
- Adds an additional flag `--conversion` to direct-csi binary
- Add testcases for the conversion (handler level)

To test :-

```
go test -v github.com/minio/direct-csi/pkg/converter -run ^TestConverter
```