### PR TITLE
Collect mountinfo based on (major, minor) pairs and code-refactoring

### DIFF
--- a/pkg/drive/drive_controller.go
+++ b/pkg/drive/drive_controller.go
@@ -234,8 +234,8 @@ func (d *DirectCSIDriveListener) Update(ctx context.Context, old, new *directv1a
 					new.Status.MountOptions = mountOpts
 					freeCapacity, sErr := getFreeCapacityFromStatfs(new.Status.Mountpoint)
 					if sErr != nil {
-						glog.Error(err)
-						updateErr = err
+						glog.Error(sErr)
+						updateErr = sErr
 					} else {
 						mounted = true
 						new.Status.FreeCapacity = freeCapacity

--- a/pkg/sys/fs_discovery_linux.go
+++ b/pkg/sys/fs_discovery_linux.go
@@ -50,7 +50,7 @@ func (b *BlockDevice) probeFS(offsetBlocks uint64) (*FSInfo, error) {
 }
 
 func (b *BlockDevice) probeFSEXT4(offsetBlocks uint64) (*FSInfo, error) {
-	devPath := getBlockFile(b.Devname)
+	devPath := b.DirectCSIDrivePath()
 	devFile, err := os.OpenFile(devPath, os.O_RDONLY, os.ModeDevice)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (b *BlockDevice) probeFSEXT4(offsetBlocks uint64) (*FSInfo, error) {
 }
 
 func (b *BlockDevice) probeFSXFS(offsetBlocks uint64) (*FSInfo, error) {
-	devPath := getBlockFile(b.Devname)
+	devPath := b.DirectCSIDrivePath()
 	devFile, err := os.OpenFile(devPath, os.O_RDONLY, os.ModeDevice)
 	if err != nil {
 		return nil, err

--- a/pkg/sys/mount_discovery_linux.go
+++ b/pkg/sys/mount_discovery_linux.go
@@ -26,25 +26,16 @@ import (
 	"strings"
 )
 
-func (b *BlockDevice) probeMountInfo(partitionNum uint) ([]MountInfo, error) {
+func (b *BlockDevice) probeMountInfo(major, minor uint32) ([]MountInfo, error) {
 	mounts, err := ProbeMountInfo()
 	if err != nil {
 		return nil, err
 	}
-	devName := b.Devname
-	newDevName := getBlockFile(devName)
-	rootDevName := getRootBlockFile(devName)
 	toRet := []MountInfo{}
 	for _, m := range mounts {
-		if m.DevName != rootDevName && m.DevName != newDevName {
-			continue
+		if major == m.MajorNumber && minor == m.MinorNumber {
+			toRet = append(toRet, m)
 		}
-		if partitionNum > 0 {
-			if m.PartitionNum != partitionNum {
-				continue
-			}
-		}
-		toRet = append(toRet, m)
 	}
 	return toRet, nil
 }
@@ -89,6 +80,19 @@ func ProbeMountInfo() ([]MountInfo, error) {
 		}
 		parentID := uint32(pID)
 
+		majorMinorParts := strings.Split(firstParts[2], ":")
+		if len(majorMinorParts) != 2 {
+			return nil, fmt.Errorf("invalid 'major:minor' format in %s", mountinfoFile)
+		}
+		majorNumber, err := strconv.ParseUint(majorMinorParts[0], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse the major number in %s", mountinfoFile)
+		}
+		minorNumber, err := strconv.ParseUint(majorMinorParts[1], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse the minor number in %s", mountinfoFile)
+		}
+
 		mountRoot := firstParts[3]
 		mountPoint := firstParts[4]
 		mountOptions := firstParts[5]
@@ -116,6 +120,8 @@ func ProbeMountInfo() ([]MountInfo, error) {
 			SuperblockOptions: superblockOptions,
 			FSType:            fsType,
 			OptionalFields:    optionalFields,
+			MajorNumber:       uint32(majorNumber),
+			MinorNumber:       uint32(minorNumber),
 			DevName:           devName,
 			PartitionNum:      uint(partNum),
 		})

--- a/pkg/sys/mount_discovery_linux.go
+++ b/pkg/sys/mount_discovery_linux.go
@@ -33,7 +33,7 @@ func (b *BlockDevice) probeMountInfo(major, minor uint32) ([]MountInfo, error) {
 	}
 	toRet := []MountInfo{}
 	for _, m := range mounts {
-		if major == m.MajorNumber && minor == m.MinorNumber {
+		if major == m.Major && minor == m.Minor {
 			toRet = append(toRet, m)
 		}
 	}
@@ -120,8 +120,8 @@ func ProbeMountInfo() ([]MountInfo, error) {
 			SuperblockOptions: superblockOptions,
 			FSType:            fsType,
 			OptionalFields:    optionalFields,
-			MajorNumber:       uint32(majorNumber),
-			MinorNumber:       uint32(minorNumber),
+			Major:             uint32(majorNumber),
+			Minor:             uint32(minorNumber),
 			DevName:           devName,
 			PartitionNum:      uint(partNum),
 		})

--- a/pkg/sys/partition_discovery_linux.go
+++ b/pkg/sys/partition_discovery_linux.go
@@ -71,7 +71,7 @@ func (b *BlockDevice) probePartitions(ctx context.Context) ([]Partition, error) 
 }
 
 func (b *BlockDevice) probeAAPMBR(ctx context.Context) ([]Partition, error) {
-	devPath := getBlockFile(b.Devname)
+	devPath := b.DirectCSIDrivePath()
 	devFile, err := os.OpenFile(devPath, os.O_RDONLY, os.ModeDevice)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (b *BlockDevice) probeAAPMBR(ctx context.Context) ([]Partition, error) {
 		}
 		partNum := uint32(i+1) + b.Minor
 		partitionPath := fmt.Sprintf("%s%s%d", b.Path, DirectCSIPartitionInfix, i+1)
-		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
+		if err := makeBlockFile(partitionPath, b.DriveInfo.Major, uint32(partNum)); err != nil {
 			return nil, err
 		}
 
@@ -108,6 +108,8 @@ func (b *BlockDevice) probeAAPMBR(ctx context.Context) ([]Partition, error) {
 				TotalCapacity:     b.LogicalBlockSize * uint64(p.NumSectors),
 				NumBlocks:         uint64(p.NumSectors),
 				Path:              partitionPath,
+				Major:             b.DriveInfo.Major,
+				Minor:             uint32(partNum),
 			},
 			PartitionNum: uint32(partNum),
 			// Type:          p.PartitionType,
@@ -121,7 +123,7 @@ func (b *BlockDevice) probeAAPMBR(ctx context.Context) ([]Partition, error) {
 }
 
 func (b *BlockDevice) probeClassicMBR(ctx context.Context) ([]Partition, error) {
-	devPath := getBlockFile(b.Devname)
+	devPath := b.DirectCSIDrivePath()
 	devFile, err := os.OpenFile(devPath, os.O_RDONLY, os.ModeDevice)
 	if err != nil {
 		return nil, err
@@ -145,7 +147,7 @@ func (b *BlockDevice) probeClassicMBR(ctx context.Context) ([]Partition, error) 
 		}
 		partNum := b.Minor + uint32(i+1)
 		partitionPath := fmt.Sprintf("%s%s%d", b.Path, DirectCSIPartitionInfix, i+1)
-		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
+		if err := makeBlockFile(partitionPath, b.DriveInfo.Major, uint32(partNum)); err != nil {
 			return nil, err
 		}
 
@@ -158,6 +160,8 @@ func (b *BlockDevice) probeClassicMBR(ctx context.Context) ([]Partition, error) 
 				TotalCapacity:     b.LogicalBlockSize * uint64(p.NumSectors),
 				NumBlocks:         uint64(p.NumSectors),
 				Path:              partitionPath,
+				Major:             b.DriveInfo.Major,
+				Minor:             uint32(partNum),
 			},
 			PartitionNum: uint32(partNum),
 			// Type:          p.PartitionType,
@@ -171,7 +175,7 @@ func (b *BlockDevice) probeClassicMBR(ctx context.Context) ([]Partition, error) 
 }
 
 func (b *BlockDevice) probeModernStandardMBR(ctx context.Context) ([]Partition, error) {
-	devPath := getBlockFile(b.Devname)
+	devPath := b.DirectCSIDrivePath()
 	devFile, err := os.OpenFile(devPath, os.O_RDONLY, os.ModeDevice)
 	if err != nil {
 		return nil, err
@@ -195,7 +199,7 @@ func (b *BlockDevice) probeModernStandardMBR(ctx context.Context) ([]Partition, 
 		}
 		partNum := b.Minor + uint32(i+1)
 		partitionPath := fmt.Sprintf("%s%s%d", b.Path, DirectCSIPartitionInfix, i+1)
-		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
+		if err := makeBlockFile(partitionPath, b.DriveInfo.Major, uint32(partNum)); err != nil {
 			return nil, err
 		}
 
@@ -208,6 +212,8 @@ func (b *BlockDevice) probeModernStandardMBR(ctx context.Context) ([]Partition, 
 				TotalCapacity:     b.LogicalBlockSize * uint64(p.NumSectors),
 				NumBlocks:         uint64(p.NumSectors),
 				Path:              partitionPath,
+				Major:             b.DriveInfo.Major,
+				Minor:             uint32(partNum),
 			},
 			PartitionNum: uint32(partNum),
 			// Type:          p.PartitionType,
@@ -221,7 +227,7 @@ func (b *BlockDevice) probeModernStandardMBR(ctx context.Context) ([]Partition, 
 }
 
 func (b *BlockDevice) probeGPT(ctx context.Context) ([]Partition, error) {
-	devPath := getBlockFile(b.Devname)
+	devPath := b.DirectCSIDrivePath()
 	devFile, err := os.OpenFile(devPath, os.O_RDONLY, os.ModeDevice)
 	if err != nil {
 		return nil, err
@@ -279,7 +285,7 @@ func (b *BlockDevice) probeGPT(ctx context.Context) ([]Partition, error) {
 
 		partNum := b.Minor + uint32(i+1)
 		partitionPath := fmt.Sprintf("%s%s%d", b.Path, DirectCSIPartitionInfix, i+1)
-		if err := makeBlockFile(partitionPath, b.Major, uint32(partNum)); err != nil {
+		if err := makeBlockFile(partitionPath, b.DriveInfo.Major, uint32(partNum)); err != nil {
 			return nil, err
 		}
 
@@ -292,6 +298,8 @@ func (b *BlockDevice) probeGPT(ctx context.Context) ([]Partition, error) {
 				TotalCapacity:     (lba.End - lba.Start) * b.LogicalBlockSize,
 				NumBlocks:         lba.End - lba.Start,
 				Path:              partitionPath,
+				Major:             b.DriveInfo.Major,
+				Minor:             uint32(partNum),
 			},
 			PartitionNum:  uint32(partNum),
 			Type:          partType,

--- a/pkg/sys/sys_utils.go
+++ b/pkg/sys/sys_utils.go
@@ -22,6 +22,14 @@ import (
 	"strings"
 )
 
+func (b *BlockDevice) DirectCSIDrivePath() string {
+	return getBlockFile(b.Devname)
+}
+
+func (b *BlockDevice) HostDrivePath() string {
+	return getRootBlockFile(b.Devname)
+}
+
 func getBlockFile(devName string) string {
 	if strings.Contains(devName, DirectCSIDevRoot) {
 		return devName
@@ -88,4 +96,15 @@ func splitDevAndPartNum(s string) (string, int) {
 		return str, numVal
 	}
 	return str, 0
+}
+
+func (b *BlockDevice) TagError(err error) {
+	b.DeviceError = err
+}
+
+func (b *BlockDevice) Error() string {
+	if b.DeviceError == nil {
+		return ""
+	}
+	return b.DeviceError.Error()
 }

--- a/pkg/sys/types.go
+++ b/pkg/sys/types.go
@@ -17,21 +17,12 @@
 package sys
 
 type BlockDevice struct {
-	Major                    uint32      `json:"major"`
-	Minor                    uint32      `json:"minor"`
-	Devname                  string      `json:"devName,omitempty"`
-	Devtype                  string      `json:"devType,omitempty"`
-	Partitions               []Partition `json:"partitions,omitempty"`
-	BlockInitializationError string      `json:"blockInitializationError"`
+	Devname     string      `json:"devName,omitempty"`
+	Devtype     string      `json:"devType,omitempty"`
+	Partitions  []Partition `json:"partitions,omitempty"`
+	DeviceError error       `json:"error, omitempty"`
 
 	*DriveInfo `json:"driveInfo,omitempty"`
-}
-
-func (b *BlockDevice) TagError(err error) {
-	if err != nil {
-		b.BlockInitializationError = err.Error()
-	}
-	return
 }
 
 type Partition struct {
@@ -52,6 +43,8 @@ type DriveInfo struct {
 	LogicalBlockSize  uint64 `json:"logicalBlockSize,omitempty"`
 	PhysicalBlockSize uint64 `json:"physicalBlockSize,omitempty"`
 	Path              string `json:"path,omitempty"`
+	Major             uint32 `json:"major,omitempty"`
+	Minor             uint32 `json:"minor",omitempty`
 
 	*FSInfo `json:"fsInfo,omitempty"`
 }
@@ -74,6 +67,8 @@ type MountInfo struct {
 	SuperblockOptions []string `json:"superblockOptions,omitempty"`
 	FSType            string   `json:"fsType,omitempty"`
 	OptionalFields    []string `json:"optionalFields,omitempty"`
+	MajorNumber       uint32   `json:"majorNumber,omitempty"`
+	MinorNumber       uint32   `json:"minorNumber,omitempty"`
 	DevName           string   `json:"devName,omitempty"`
 	PartitionNum      uint     `json:"partitionNum,omitempty"`
 }

--- a/pkg/sys/types.go
+++ b/pkg/sys/types.go
@@ -67,8 +67,8 @@ type MountInfo struct {
 	SuperblockOptions []string `json:"superblockOptions,omitempty"`
 	FSType            string   `json:"fsType,omitempty"`
 	OptionalFields    []string `json:"optionalFields,omitempty"`
-	MajorNumber       uint32   `json:"majorNumber,omitempty"`
-	MinorNumber       uint32   `json:"minorNumber,omitempty"`
+	Major             uint32   `json:"major,omitempty"`
+	Minor             uint32   `json:"minor,omitempty"`
 	DevName           string   `json:"devName,omitempty"`
 	PartitionNum      uint     `json:"partitionNum,omitempty"`
 }


### PR DESCRIPTION
- Add MajorNumber, MinorNumber fields in MountInfo
- Refactor blockdevice error tagging
- Minor refactoring work on block device utilities