### PR TITLE
Remove noatime mount option while safemounting

### DIFF
--- a/pkg/drive/utils.go
+++ b/pkg/drive/utils.go
@@ -42,7 +42,6 @@ func mountDrive(source, target string, mountOpts []string) error {
 		}
 		return newOpts
 	}(mountOpts), []string{
-		"noatime",
 		"prjquota",
 	})
 


### PR DESCRIPTION
Mounting was failing when tried to mount with 'noatime' set

```
I0301 08:41:51.204129 2848294 utils.go:37] mounting drive /var/lib/direct-csi/devices/nvme1n-part-1 at /var/lib/direct-csi/mnt/e31d7a619f8c356c506aecc348470bc7b4aae313e102859407cfb8be60bf8030
E0301 08:41:51.204826 2848294 drive_controller.go:230] failed to mount drive: e31d7a619f8c356c506aecc348470bc7b4aae313e102859407cfb8be60bf8030 invalid argument
```

dmesg logs :-

![image](https://user-images.githubusercontent.com/5410427/109532612-4b9fed80-7adf-11eb-9190-330a7079d02b.png)
