### PR TITLE
Add tagging support to DirectCSI drives

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of MinIO Direct CSI
-# Copyright (c) 2020 MinIO, Inc.
+# Copyright (c) 2021 MinIO, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/cmd/kubectl-direct_csi/drive_accesstier.go
+++ b/cmd/kubectl-direct_csi/drive_accesstier.go
@@ -16,25 +16,22 @@
  *
  */
 
-package sys
+package main
 
 import (
-	"context"
-
-	"os/exec"
+	"github.com/spf13/cobra"
 )
 
-func Format(ctx context.Context, path, fs string, options []string, force bool) (string, error) {
-	bin := "mkfs." + fs
-	args := func() []string {
-		args := options
-		if force {
-			args = append(args, "-f")
-		}
-		return append(args, path)
-	}()
+var drivesAccessTierCmd = &cobra.Command{
+	Use:   "access-tier",
+	Short: "tag/untag DirectCSI drives based on thier access-tiers",
+	Long:  "",
+	Aliases: []string{
+		"accesstier",
+	},
+}
 
-	cmd := exec.CommandContext(ctx, bin, args...)
-	outputBytes, err := cmd.CombinedOutput()
-	return string(outputBytes), err
+func init() {
+	drivesAccessTierCmd.AddCommand(accessTierSet)
+	drivesAccessTierCmd.AddCommand(accessTierUnset)
 }

--- a/cmd/kubectl-direct_csi/drive_accesstier_set.go
+++ b/cmd/kubectl-direct_csi/drive_accesstier_set.go
@@ -1,0 +1,122 @@
+/*
+ * This file is part of MinIO Direct CSI
+ * Copyright (C) 2021, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
+	"github.com/minio/direct-csi/pkg/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var accessTierSet = &cobra.Command{
+	Use:   "set [hot|cold|warm]",
+	Short: "tag DirectCSI drive(s) based on their access-tiers [hot,cold,warm]",
+	Long:  "",
+	Example: `
+# Sets the 'access-tier:cold' tag to all the 'Available' DirectCSI drives 
+$ kubectl direct-csi drives access-tier set cold --all
+
+# Sets the 'access-tier:warm' tag to all nvme drives in all nodes 
+$ kubectl direct-csi drives access-tier set warm --drives=/dev/nvme*
+
+# Sets the 'access-tier:hot' tag to all drives from a particular node
+$ kubectl direct-csi drives access-tier set hot --nodes=directcsi-1
+
+# Combine multiple parameters using multi-arg
+$ kubectl direct-csi drives access-tier set hot --nodes=directcsi-1 --nodes=othernode-2 --status=ready
+
+# Combine multiple parameters using csv
+$ kubectl direct-csi drives access-tier set hot --nodes=directcsi-1,othernode-2 --status=ready
+`,
+	RunE: func(c *cobra.Command, args []string) error {
+		return setAccessTier(c.Context(), args)
+	},
+	Aliases: []string{},
+}
+
+func init() {
+	accessTierSet.PersistentFlags().StringSliceVarP(&drives, "drives", "d", drives, "glob selector for drive paths")
+	accessTierSet.PersistentFlags().StringSliceVarP(&nodes, "nodes", "n", nodes, "glob selector for node names")
+	accessTierSet.PersistentFlags().BoolVarP(&all, "all", "a", all, "tag all available drives")
+	accessTierSet.PersistentFlags().StringSliceVarP(&status, "status", "s", status, "glob prefix match for drive status")
+}
+
+func setAccessTier(ctx context.Context, args []string) error {
+	dryRun := viper.GetBool(dryRunFlagName)
+	if !all {
+		if len(drives) == 0 && len(nodes) == 0 && len(status) == 0 {
+			return fmt.Errorf("atleast one of '%s', '%s', '%s' or '%s' should be specified", utils.Bold("--all"), utils.Bold("--drives"), utils.Bold("--nodes"), utils.Bold("--status"))
+		}
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("Invalid input arguments. Please use '%s' for examples to set access-tiers", utils.Bold("--help"))
+	}
+
+	accessT, err := utils.ValidateAccessTier(args[0])
+	if err != nil {
+		return err
+	}
+
+	utils.Init()
+
+	directClient := utils.GetDirectCSIClient()
+	driveList, err := directClient.DirectCSIDrives().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(driveList.Items) == 0 {
+		glog.Errorf("No resource of %s found\n", bold("DirectCSIDrive"))
+		return fmt.Errorf("No resources found")
+	}
+
+	filterDrives := []directcsi.DirectCSIDrive{}
+	for _, d := range driveList.Items {
+		if d.MatchGlob(nodes, drives, status) {
+			filterDrives = append(filterDrives, d)
+		}
+	}
+
+	for _, d := range filterDrives {
+		if d.Status.DriveStatus == directcsi.DriveStatusUnavailable {
+			continue
+		}
+		d.Status.AccessTier = accessT
+		if dryRun {
+			if err := utils.LogYAML(d); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := directClient.DirectCSIDrives().Update(ctx, &d, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/kubectl-direct_csi/drive_accesstier_unset.go
+++ b/cmd/kubectl-direct_csi/drive_accesstier_unset.go
@@ -1,0 +1,118 @@
+/*
+ * This file is part of MinIO Direct CSI
+ * Copyright (C) 2021, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
+	"github.com/minio/direct-csi/pkg/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+var accessTierUnset = &cobra.Command{
+	Use:   "unset",
+	Short: "remove the access-tier tag from the DirectCSI drive(s)",
+	Long:  "",
+	Example: `
+# Unsets the 'access-tier' tag on all the 'Available' DirectCSI drives 
+$ kubectl direct-csi drives access-tier unset --all
+
+# Unsets the 'access-tier' based on the tier value set
+$ kubectl direct-csi drives access-tier unset --access-tier=warm
+
+# Unsets the 'access-tier' tag on all the drives from a particular node
+$ kubectl direct-csi drives access-tier unset --nodes=directcsi-1
+
+# Combine multiple parameters using multi-arg
+$ kubectl direct-csi drives access-tier unset --nodes=directcsi-1 --nodes=othernode-2 --status=ready
+
+# Combine multiple parameters using csv
+$ kubectl direct-csi drives access-tier unset --nodes=directcsi-1,othernode-2 --access-tier=hot
+`,
+	RunE: func(c *cobra.Command, args []string) error {
+		return unsetAccessTier(c.Context(), args)
+	},
+	Aliases: []string{},
+}
+
+func init() {
+	accessTierUnset.PersistentFlags().StringSliceVarP(&drives, "drives", "d", drives, "glob selector for drive paths")
+	accessTierUnset.PersistentFlags().StringSliceVarP(&nodes, "nodes", "n", nodes, "glob selector for node names")
+	accessTierUnset.PersistentFlags().BoolVarP(&all, "all", "a", all, "untag all available drives")
+	accessTierUnset.PersistentFlags().StringSliceVarP(&status, "status", "s", status, "glob prefix match for drive status")
+	accessTierUnset.PersistentFlags().StringSliceVarP(&accessTiers, "access-tier", "", accessTiers, "format based on access-tier set. The possible values are [hot,cold,warm] ")
+}
+
+func unsetAccessTier(ctx context.Context, args []string) error {
+	if dryRun {
+		glog.Infof("'%s' flag is not supported for access-tier subcommand", bold(dryRunFlagName))
+		return nil
+	}
+
+	if !all {
+		if len(drives) == 0 && len(nodes) == 0 && len(status) == 0 && len(accessTiers) == 0 {
+			return fmt.Errorf("atleast one of ['%s','%s','%s','%s','%s'] should be specified", utils.Bold("--all"), utils.Bold("--drives"), utils.Bold("--nodes"), utils.Bold("--status"), utils.Bold("--access-tier"))
+		}
+	}
+
+	utils.Init()
+
+	directClient := utils.GetDirectCSIClient()
+	driveList, err := directClient.DirectCSIDrives().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(driveList.Items) == 0 {
+		glog.Errorf("No resource of %s found\n", bold("DirectCSIDrive"))
+		return fmt.Errorf("No resources found")
+	}
+
+	accessTierSet, aErr := getAccessTierSet(accessTiers)
+	if aErr != nil {
+		return aErr
+	}
+	filterDrives := []directcsi.DirectCSIDrive{}
+	for _, d := range driveList.Items {
+		if all {
+			filterDrives = append(filterDrives, d)
+			continue
+		}
+		if d.MatchGlob(nodes, drives, status) {
+			if d.MatchAccessTier(accessTierSet) {
+				filterDrives = append(filterDrives, d)
+			}
+		}
+	}
+
+	for _, d := range filterDrives {
+		d.Status.AccessTier = directcsi.AccessTierUnknown
+		if _, err := directClient.DirectCSIDrives().Update(ctx, &d, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/kubectl-direct_csi/drives.go
+++ b/cmd/kubectl-direct_csi/drives.go
@@ -1,6 +1,6 @@
 /*
  * This file is part of MinIO Direct CSI
- * Copyright (C) 2020, MinIO, Inc.
+ * Copyright (C) 2021, MinIO, Inc.
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,
@@ -23,14 +23,15 @@ import (
 )
 
 var (
-	drives = []string{}
-	nodes  = []string{}
-	status = []string{}
+	drives      = []string{}
+	nodes       = []string{}
+	status      = []string{}
+	accessTiers = []string{}
 )
 
 var drivesCmd = &cobra.Command{
 	Use:   "drives",
-	Short: "Mangage Drives on DirectCSI",
+	Short: "Manage Drives on DirectCSI",
 	Long:  "",
 	Aliases: []string{
 		"drive",
@@ -41,4 +42,5 @@ var drivesCmd = &cobra.Command{
 func init() {
 	drivesCmd.AddCommand(listDrivesCmd)
 	drivesCmd.AddCommand(formatDrivesCmd)
+	drivesCmd.AddCommand(drivesAccessTierCmd)
 }

--- a/cmd/kubectl-direct_csi/utils.go
+++ b/cmd/kubectl-direct_csi/utils.go
@@ -17,9 +17,12 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/fatih/color"
 
 	directv1beta1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
+	"github.com/minio/direct-csi/pkg/utils"
 )
 
 // pretty printing utils
@@ -40,4 +43,21 @@ func ListVolumesInDrive(drive directv1beta1.DirectCSIDrive, volumes *directv1bet
 		}
 	}
 	return vols
+}
+
+func getAccessTierSet(accessTiers []string) ([]directv1beta1.AccessTier, error) {
+	var atSet []directv1beta1.AccessTier
+	for i := range accessTiers {
+		if accessTiers[i] == "*" {
+			return []directv1beta1.AccessTier{directv1beta1.AccessTierHot,
+				directv1beta1.AccessTierWarm,
+				directv1beta1.AccessTierCold}, nil
+		}
+		at, err := utils.ValidateAccessTier(strings.TrimSpace(accessTiers[i]))
+		if err != nil {
+			return atSet, err
+		}
+		atSet = append(atSet, at)
+	}
+	return atSet, nil
 }

--- a/cmd/kubectl-direct_csi/volumes.go
+++ b/cmd/kubectl-direct_csi/volumes.go
@@ -1,6 +1,6 @@
 /*
  * This file is part of MinIO Direct CSI
- * Copyright (C) 2020, MinIO, Inc.
+ * Copyright (C) 2021, MinIO, Inc.
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,
@@ -20,6 +20,10 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+)
+
+var (
+	volumeStatus = []string{}
 )
 
 var volumesCmd = &cobra.Command{

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,17 +57,17 @@ Examples:
 # Filter all nvme drives in all nodes 
 $ kubectl direct-csi drives list --drives=/dev/nvme*
 
-# Filter all new drives 
-$ kubectl direct-csi drives list --status=new
+# Filter all available drives 
+$ kubectl direct-csi drives list --status=available
 
 # Filter all drives from a particular node
 $ kubectl direct-csi drives list --nodes=directcsi-1
 
 # Combine multiple filters
-$ kubectl direct-csi drives list --nodes=directcsi-1 --nodes=othernode-2 --status=new
+$ kubectl direct-csi drives list --nodes=directcsi-1 --nodes=othernode-2 --status=ready
 
 # Combine multiple filters using csv
-$ kubectl direct-csi drives list --nodes=directcsi-1,othernode-2 --status=new
+$ kubectl direct-csi drives list --nodes=directcsi-1,othernode-2 --status=ready
 ```
 
 **EXAMPLE** When direct-csi is first installed, the output will look something like this, with most drives in `Available` status
@@ -102,17 +102,14 @@ $ kubectl direct-csi drives format --all
 # Add all nvme drives in all nodes 
 $ kubectl direct-csi drives format --drives=/dev/nvme*
 
-# Add all new drives
-$ kubectl direct-csi drives format --status=new
-
 # Add all drives from a particular node
 $ kubectl direct-csi drives format --nodes=directcsi-1
 
 # Combine multiple parameters using multi-arg
-$ kubectl direct-csi drives format --nodes=directcsi-1 --nodes=othernode-2 --status=new
+$ kubectl direct-csi drives format --nodes=directcsi-1 --nodes=othernode-2 --status=ready
 
 # Combine multiple parameters using csv
-$ kubectl direct-csi drives format --nodes=directcsi-1,othernode-2 --status=new
+$ kubectl direct-csi drives format --nodes=directcsi-1,othernode-2 --status=ready
 
 Flags:
   -d, --drives strings      glog selector for drive paths

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Documentation
 ### Setup and Usage
  - [Installation](./installation.md)
  - [CLI reference](./cli.md)
+ - [Scheduling](./scheduling.md)
 
 ### Advanced
  - [Architecture](./architecture.md)

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,46 @@
+---
+title: Scheduling
+---
+
+Scheduling guidelines
+-------------
+
+### Access-tier based volume scheduling
+
+In addition to scheduling based on resource constraints (available space) and node topology (affinity/anti-affinity etc.), it is possible to further influence the scheduling of workloads to specific volumes based on "access-tiers". DirectCSI pre-defines 3 access tiers:
+
+- Hot
+- Warm
+- Cold
+
+By default, direct-csi drives are not associated with any access-tier. An admin can associate drives to access tiers. Further instructions on the configuration is provided in the following sections.
+
+#### Step 1: Set access-tier tag on the drives
+
+```
+kubectl direct-csi drives access-tier set hot|cold|warm [FLAGS]
+```
+
+#### Step 2: Format the tiered drives (Incase of fresh/available drives)
+
+```
+kubectl direct-csi drives format --access-tier=hot|cold|warm
+```
+
+#### Step 3: Set the 'direct-csi-min-io/access-tier' parameter in storage class definition
+
+Create a storage class with the following parameter set
+
+```
+parameters:
+  direct-csi-min-io/access-tier: warm|hot|cold
+```
+
+#### Step 4: Deploy the workload with the corresponding storage class name set
+
+You will see volumes placed on the tiered drives only. You can verify this by the following set of commands
+
+```
+kubectl direct-csi volumes ls --access-tier=warm|hot|cold
+kubectl direct-csi drives ls --access-tier=warm|hot|cold
+```

--- a/hack/build-without-docker.sh
+++ b/hack/build-without-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of MinIO Direct CSI
-# Copyright (c) 2020 MinIO, Inc.
+# Copyright (c) 2021 MinIO, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of MinIO Direct CSI
-# Copyright (c) 2020 MinIO, Inc.
+# Copyright (c) 2021 MinIO, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/pkg/apis/direct.csi.min.io/v1beta1/drive_matcher.go
+++ b/pkg/apis/direct.csi.min.io/v1beta1/drive_matcher.go
@@ -1,0 +1,72 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1beta1
+
+import (
+	"github.com/mb0/glob"
+	"github.com/minio/direct-csi/pkg/sys"
+	"path/filepath"
+	"strings"
+)
+
+func (drive *DirectCSIDrive) MatchGlob(nodes, drives, status []string) bool {
+
+	getBasePath := func(in string) string {
+		path := strings.ReplaceAll(in, sys.DirectCSIPartitionInfix, "")
+		path = strings.ReplaceAll(path, sys.DirectCSIDevRoot+"/", "")
+		path = strings.ReplaceAll(path, sys.HostDevRoot+"/", "")
+		return filepath.Base(path)
+	}
+
+	matchGlob := func(patternList []string, name string, transformF transformFunc) bool {
+		name = transformF(name)
+		for _, p := range patternList {
+			if ok, _ := glob.Match(p, name); ok {
+				return true
+			}
+			if ok, _ := glob.Match(p+"*", name); ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	nodeList, driveList, statusesList := checkWildcards(nodes),
+		fmap(checkWildcards(drives), getBasePath),
+		fmap(checkWildcards(status), strings.ToLower)
+
+	var noOp transformFunc
+	noOp = func(a string) string {
+		return a
+	}
+
+	return matchGlob(nodeList, drive.Status.NodeName, noOp) &&
+		matchGlob(driveList, drive.Status.Path, getBasePath) &&
+		matchGlob(statusesList, string(drive.Status.DriveStatus), strings.ToLower)
+}
+
+func (drive *DirectCSIDrive) MatchAccessTier(accessTierList []AccessTier) bool {
+	if len(accessTierList) == 0 {
+		return true
+	}
+	for _, at := range accessTierList {
+		if drive.Status.AccessTier == at {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/apis/direct.csi.min.io/v1beta1/matcher_utils.go
+++ b/pkg/apis/direct.csi.min.io/v1beta1/matcher_utils.go
@@ -1,0 +1,35 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1beta1
+
+type transformFunc func(src string) string
+
+func fmap(vs []string, f func(string) string) []string {
+	vsm := make([]string, len(vs))
+	for i, v := range vs {
+		vsm[i] = f(v)
+	}
+	return vsm
+}
+
+func checkWildcards(globElems []string) []string {
+	isStarPattern := func() bool { return len(globElems) == 1 && globElems[0] == "*" }
+	if len(globElems) == 0 || isStarPattern() {
+		globElems = []string{"**"}
+	}
+	return globElems
+}

--- a/pkg/apis/direct.csi.min.io/v1beta1/volume_matcher.go
+++ b/pkg/apis/direct.csi.min.io/v1beta1/volume_matcher.go
@@ -1,0 +1,49 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1beta1
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (volume *DirectCSIVolume) MatchStatus(statusList []string) bool {
+	statusXs := fmap(statusList, strings.ToLower)
+	statusMatches := 0
+	for _, c := range volume.Status.Conditions {
+		switch c.Type {
+		case string(DirectCSIVolumeConditionPublished):
+			for _, statusX := range statusXs {
+				if statusX == strings.ToLower(string(DirectCSIVolumeConditionPublished)) {
+					if c.Status == metav1.ConditionTrue {
+						statusMatches = statusMatches + 1
+					}
+				}
+			}
+		case string(DirectCSIVolumeConditionStaged):
+			for _, statusX := range statusXs {
+				if statusX == strings.ToLower(string(DirectCSIVolumeConditionStaged)) {
+					if c.Status == metav1.ConditionTrue {
+						statusMatches = statusMatches + 1
+					}
+				}
+			}
+		}
+	}
+	return statusMatches == len(statusXs)
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -532,3 +532,199 @@ func TestFilterDrivesByRequestedFormat(t1 *testing.T) {
 		})
 	}
 }
+
+func TestFilterDrivesByParameters(t1 *testing.T) {
+	testCases := []struct {
+		name              string
+		parameters        map[string]string
+		driveList         []directcsi.DirectCSIDrive
+		selectedDriveList []directcsi.DirectCSIDrive
+		expectError       bool
+	}{
+		{
+			name:       "test1",
+			parameters: map[string]string{"abc": "def"},
+			driveList: []directcsi.DirectCSIDrive{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive1",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive2",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive3",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierCold,
+					},
+				},
+			},
+			selectedDriveList: []directcsi.DirectCSIDrive{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive1",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive2",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive3",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierCold,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:       "test2",
+			parameters: map[string]string{"direct-csi-min-io/access-tier": "hot", "abc": "def"},
+			driveList: []directcsi.DirectCSIDrive{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive1",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive2",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive3",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+			},
+			selectedDriveList: []directcsi.DirectCSIDrive{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive1",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive2",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:       "test3",
+			parameters: map[string]string{"direct-csi-min-io/access-tier": "cold", "abc": "def"},
+			driveList: []directcsi.DirectCSIDrive{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive1",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive2",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive3",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+			},
+			selectedDriveList: []directcsi.DirectCSIDrive{},
+			expectError:       false,
+		},
+		{
+			name:       "test4",
+			parameters: map[string]string{"direct-csi-min-io/access-tier": "inVaLidValue", "abc": "def"},
+			driveList: []directcsi.DirectCSIDrive{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive1",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive2",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierHot,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "drive3",
+					},
+					Status: directcsi.DirectCSIDriveStatus{
+						AccessTier: directcsi.AccessTierUnknown,
+					},
+				},
+			},
+			selectedDriveList: []directcsi.DirectCSIDrive{},
+			expectError:       true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			driveList, err := FilterDrivesByParameters(tt.parameters, tt.driveList)
+			if err != nil {
+				if !tt.expectError {
+					t1.Errorf("Test case name %s: Failed with %v", tt.name, err)
+				}
+			} else {
+				if !reflect.DeepEqual(driveList, tt.selectedDriveList) {
+					t1.Errorf("Test case name %s: Expected drive list = %v, got %v", tt.name, tt.selectedDriveList, driveList)
+				}
+			}
+		})
+	}
+}

--- a/pkg/sys/mount_linux.go
+++ b/pkg/sys/mount_linux.go
@@ -1,6 +1,6 @@
 /*
  * This file is part of MinIO Direct CSI
- * Copyright (C) 2020, MinIO, Inc.
+ * Copyright (C) 2021, MinIO, Inc.
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,

--- a/pkg/utils/installer/randomstring.go
+++ b/pkg/utils/installer/randomstring.go
@@ -1,6 +1,6 @@
 /*
  * This file is part of MinIO Direct CSI
- * Copyright (C) 2020, MinIO, Inc.
+ * Copyright (C) 2021, MinIO, Inc.
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,

--- a/pkg/utils/installer/rbac.go
+++ b/pkg/utils/installer/rbac.go
@@ -1,6 +1,6 @@
 /*
  * This file is part of MinIO Direct CSI
- * Copyright (C) 2020, MinIO, Inc.
+ * Copyright (C) 2021, MinIO, Inc.
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,7 +18,9 @@ package utils
 
 import (
 	"encoding/json"
+	"strings"
 
+	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/yaml"
@@ -57,4 +59,19 @@ func PrintYaml(data []byte) {
 	fmt.Println()
 	fmt.Println("---")
 	fmt.Println()
+}
+
+func ValidateAccessTier(at string) (directcsi.AccessTier, error) {
+	switch directcsi.AccessTier(strings.Title(at)) {
+	case directcsi.AccessTierWarm:
+		return directcsi.AccessTierWarm, nil
+	case directcsi.AccessTierHot:
+		return directcsi.AccessTierHot, nil
+	case directcsi.AccessTierCold:
+		return directcsi.AccessTierCold, nil
+	case directcsi.AccessTierUnknown:
+		return directcsi.AccessTierUnknown, fmt.Errorf("Please set any one among ['hot','warm', 'cold']")
+	default:
+		return directcsi.AccessTierUnknown, fmt.Errorf("Invalid 'access-tier' value, Please set any one among ['hot','warm','cold']")
+	}
 }


### PR DESCRIPTION
**The PR does the following things**

- Adds the following commands to the plugin
```
kubectl direct-csi drives access-tier set cold|warm|hot [FLAGS]
kubectl direct-csi drives access-tier unset [FLAGS]
```

- Supports access-tier based scheduling of volumes

When the storageclass definition has `direct-csi-min-io/access-tier: hot|cold|warm`
parameter defined, The volumes will be scheduled on those selected tiered drives

- Isolates the glob match logic and some major plugin code refactorings

**Testing outcomes :-**

```
➜  direct-csi git:(addtags) ✗ kubectl get storageclass direct-csi-min-io -o yaml | grep "parameters:" -A 2
      f:parameters:
        .: {}
        f:direct-csi-min-io/access-tier: {}
--
parameters:
  direct-csi-min-io/access-tier: warm
  fstype: xfs
➜  direct-csi git:(addtags) ✗ ./kubectl-direct_csi drives ls --status=inuse                               
 DRIVE         CAPACITY  ALLOCATED  VOLUMES  NODE        ACCESS-TIER  STATUS   
 /dev/nvme1n1  932 GiB   11 GiB     2        minio-k8s2  warm         InUse    
 /dev/nvme2n1  932 GiB   11 GiB     2        minio-k8s2  warm         InUse    
 /dev/nvme1n1  932 GiB   11 GiB     2        minio-k8s3  warm         InUse    
 /dev/nvme2n1  932 GiB   11 GiB     2        minio-k8s3  warm         InUse    
 /dev/nvme1n1  932 GiB   11 GiB     2        minio-k8s4  warm         InUse    
 /dev/nvme2n1  932 GiB   11 GiB     2        minio-k8s4  warm         InUse    
 /dev/nvme1n1  932 GiB   11 GiB     2        minio-k8s6  warm         InUse    
 /dev/nvme2n1  932 GiB   11 GiB     2        minio-k8s6  warm         InUse    
➜  direct-csi git:(addtags) ✗ ./kubectl-direct_csi volumes ls | wc -l                                     
17
➜  direct-csi git:(addtags) ✗ ./kubectl-direct_csi volumes ls --access-tier=warm | wc -l
17
➜  direct-csi git:(addtags) ✗ ./kubectl-direct_csi info                                 
 NODE          CAPACITY  ALLOCATED  VOLUMES  DRIVES 
 • minio-k8s2  9.6 TiB   8.0 GiB    4        12     
 • minio-k8s3  9.6 TiB   8.0 GiB    4        12     
 • minio-k8s4  9.6 TiB   8.0 GiB    4        12     
 • minio-k8s5  9.6 TiB   0 B        0        12     
 • minio-k8s6  9.6 TiB   8.0 GiB    4        12     
 • minio-k8s7  9.6 TiB   0 B        0        12     
 • minio-k8s8  9.6 TiB   0 B        0        12     

32 GiB/67 TiB used, 16 volumes, 84 drives
➜  direct-csi git:(addtags) ✗ 
```