### PR TITLE
Do not mask errors on loop device cleanups

### DIFF
--- a/pkg/sys/loopback/loopback_linux.go
+++ b/pkg/sys/loopback/loopback_linux.go
@@ -184,7 +184,7 @@ func getInfo(fd uintptr) (LoopInfo, error) {
 func RemoveLoopDevice(loopPath string) error {
 	loopFile, err := os.OpenFile(loopPath, os.O_RDONLY, 0660)
 	if err != nil {
-		return fmt.Errorf("could not open loop device")
+		return err
 	}
 	defer loopFile.Close()
 


### PR DESCRIPTION
To preserve idem-potency on loop device cleanups, We should not mask (forget) any errors on removals. This may escape the `os.IsNotExist` checks. 