### PR TITLE
Add missing TypeMeta in `--dry-run` while syncing CRDs and bugfixes

### DIFF
--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -195,6 +195,11 @@ func uninstall(ctx context.Context, args []string) error {
 				return err
 			}
 		}
+		if err := installer.DeleteConversionWebhookCertsSecret(ctx, identity); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
 		glog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
 	}
 

--- a/pkg/utils/installer/uninstall.go
+++ b/pkg/utils/installer/uninstall.go
@@ -172,3 +172,10 @@ func DeleteConversionSecret(ctx context.Context, identity string) error {
 	}
 	return nil
 }
+
+func DeleteConversionWebhookCertsSecret(ctx context.Context, identity string) error {
+	if err := utils.GetKubeClient().CoreV1().Secrets(sanitizeName(identity)).Delete(ctx, conversionWebhookCertsSecret, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- Avoid globals and read the conversion CA bundle from secret
- Add `TypeMeta` while syncing CRDs during upgrade [For reference - https://github.com/kubernetes/client-go/issues/413]
- Add missing cleanups during uninstall