### PR TITLE
Set LogLevel to 0 for logs in install/uninstall

### DIFF
--- a/cmd/kubectl-direct_csi/drive_accesstier_unset.go
+++ b/cmd/kubectl-direct_csi/drive_accesstier_unset.go
@@ -67,7 +67,7 @@ func init() {
 
 func unsetAccessTier(ctx context.Context, args []string) error {
 	if dryRun {
-		klog.V(1).Infof("'%s' flag is not supported for access-tier subcommand", bold(dryRunFlagName))
+		klog.Infof("'%s' flag is not supported for access-tier subcommand", bold(dryRunFlagName))
 		return nil
 	}
 

--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -95,14 +95,14 @@ func install(ctx context.Context, args []string) error {
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' namespace created", utils.Bold(identity))
+		klog.Infof("'%s' namespace created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
 		return err
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' conversion deployment created", utils.Bold(identity))
+		klog.Infof("'%s' conversion deployment created", utils.Bold(identity))
 	}
 
 crdInstall:
@@ -123,7 +123,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("crds successfully registered")
+		klog.Infof("crds successfully registered")
 	}
 
 	if err := installer.CreateCSIDriver(ctx, identity, dryRun); err != nil {
@@ -132,7 +132,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' csidriver created", utils.Bold(identity))
+		klog.Infof("'%s' csidriver created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateStorageClass(ctx, identity, dryRun); err != nil {
@@ -141,7 +141,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' storageclass created", utils.Bold(identity))
+		klog.Infof("'%s' storageclass created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateService(ctx, identity, dryRun); err != nil {
@@ -150,7 +150,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' service created", utils.Bold(identity))
+		klog.Infof("'%s' service created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateRBACRoles(ctx, identity, dryRun); err != nil {
@@ -159,7 +159,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' rbac roles created", utils.Bold(identity))
+		klog.Infof("'%s' rbac roles created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateDaemonSet(ctx, identity, image, dryRun, registry, org, loopBackOnly, nodeSelector, tolerations); err != nil {
@@ -168,7 +168,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' daemonset created", utils.Bold(identity))
+		klog.Infof("'%s' daemonset created", utils.Bold(identity))
 	}
 
 	if err := installer.CreateDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
@@ -177,7 +177,7 @@ crdInstall:
 		}
 	}
 	if !dryRun {
-		klog.V(1).Infof("'%s' deployment created", utils.Bold(identity))
+		klog.Infof("'%s' deployment created", utils.Bold(identity))
 	}
 
 	if admissionControl {
@@ -187,7 +187,7 @@ crdInstall:
 			}
 		}
 		if !dryRun {
-			klog.V(1).Infof("'%s' drive validation rules registered", utils.Bold(identity))
+			klog.Infof("'%s' drive validation rules registered", utils.Bold(identity))
 		}
 	}
 

--- a/cmd/kubectl-direct_csi/register.go
+++ b/cmd/kubectl-direct_csi/register.go
@@ -129,7 +129,7 @@ func syncCRD(ctx context.Context, existingCRD *apiextensions.CustomResourceDefin
 		return err
 	}
 
-	klog.V(1).Infof("'%s' CRD succesfully updated to '%s'", existingCRD.Name, utils.Bold(currentCRDStorageVersion))
+	klog.Infof("'%s' CRD succesfully updated to '%s'", existingCRD.Name, utils.Bold(currentCRDStorageVersion))
 
 	return nil
 }

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -54,7 +54,7 @@ func uninstall(ctx context.Context, args []string) error {
 
 	dryRun := viper.GetBool(dryRunFlagName)
 	if dryRun {
-		klog.V(1).Infof("'%s' flag is not supported for uninstall", bold(dryRunFlagName))
+		klog.Infof("'%s' flag is not supported for uninstall", bold(dryRunFlagName))
 		return nil
 	}
 
@@ -110,7 +110,7 @@ func uninstall(ctx context.Context, args []string) error {
 			}
 		}
 		if forceRemove {
-			klog.V(1).Infof("'%s' CRD resources deleted", bold(identity))
+			klog.Infof("'%s' CRD resources deleted", bold(identity))
 		}
 
 		if err := unregisterCRDs(ctx); err != nil {
@@ -118,14 +118,14 @@ func uninstall(ctx context.Context, args []string) error {
 				return err
 			}
 		}
-		klog.V(1).Infof("'%s' crds deleted", bold(identity))
+		klog.Infof("'%s' crds deleted", bold(identity))
 
 		if err := installer.DeleteNamespace(ctx, identity); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
 			}
 		}
-		klog.V(1).Infof("'%s' namespace deleted", bold(identity))
+		klog.Infof("'%s' namespace deleted", bold(identity))
 	}
 
 	if err := installer.DeleteCSIDriver(ctx, identity); err != nil {
@@ -133,35 +133,35 @@ func uninstall(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' csidriver deleted", bold(identity))
+	klog.Infof("'%s' csidriver deleted", bold(identity))
 
 	if err := installer.DeleteStorageClass(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' storageclass deleted", bold(identity))
+	klog.Infof("'%s' storageclass deleted", bold(identity))
 
 	if err := installer.DeleteService(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' service deleted", bold(identity))
+	klog.Infof("'%s' service deleted", bold(identity))
 
 	if err := installer.RemoveRBACRoles(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' rbac roles deleted", utils.Bold(identity))
+	klog.Infof("'%s' rbac roles deleted", utils.Bold(identity))
 
 	if err := installer.DeleteDaemonSet(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' daemonset deleted", utils.Bold(identity))
+	klog.Infof("'%s' daemonset deleted", utils.Bold(identity))
 
 	if err := installer.DeleteDriveValidationRules(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
@@ -174,14 +174,14 @@ func uninstall(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' drive validation rules removed", utils.Bold(identity))
+	klog.Infof("'%s' drive validation rules removed", utils.Bold(identity))
 
 	if err := installer.DeleteControllerDeployment(ctx, identity); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
-	klog.V(1).Infof("'%s' controller deployment deleted", utils.Bold(identity))
+	klog.Infof("'%s' controller deployment deleted", utils.Bold(identity))
 
 	if uninstallCRD {
 		if err := installer.DeleteConversionDeployment(ctx, identity); err != nil {
@@ -202,7 +202,7 @@ func uninstall(ctx context.Context, args []string) error {
 			}
 		}
 
-		klog.V(1).Infof("'%s' conversion deployment deleted", utils.Bold(identity))
+		klog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
 	}
 
 	return nil


### PR DESCRIPTION
Right now, the installation and uninstallation does not print any log lines

```
➜  direct-csi git:(fix-klog) ./kubectl-direct_csi install --org praveen0 --image direct-csi:remounts
➜  direct-csi git:(fix-klog
```
