### PR TITLE
Fix glob selector to not support * wildcards by default

### DIFF
--- a/pkg/apis/direct.csi.min.io/v1beta2/drive_matcher.go
+++ b/pkg/apis/direct.csi.min.io/v1beta2/drive_matcher.go
@@ -38,9 +38,6 @@ func (drive *DirectCSIDrive) MatchGlob(nodes, drives, status []string) bool {
 			if ok, _ := glob.Match(p, name); ok {
 				return true
 			}
-			if ok, _ := glob.Match(p+"*", name); ok {
-				return true
-			}
 		}
 		return false
 	}


### PR DESCRIPTION
Related to https://github.com/minio/direct-csi/pull/255, Should have missed this while refactoring.