### PR TITLE
Handle abnormal delete volume calls and fix pv directory clean-up upon volume deletion 

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -387,6 +387,11 @@ func (c *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 		return nil, status.Errorf(codes.NotFound, "could not retreive volume [%s]: %v", vID, err)
 	}
 
+	if vol.Status.StagingPath != "" || vol.Status.ContainerPath != "" {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"waiting for volume [%s] to be unstaged before deleting", vID)
+	}
+
 	finalizers := vol.GetFinalizers()
 	updatedFinalizers := []string{}
 	for _, f := range finalizers {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -980,6 +980,29 @@ func TestAbnormalDeleteVolume(t1 *testing.T) {
 				ContainerPath: "",
 				StagingPath:   "/path/stagingpath",
 				UsedCapacity:  int64(50),
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionStaged),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionPublished),
+						Status:             metav1.ConditionFalse,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonNotInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionReady),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonReady),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
 			},
 		},
 		&directcsi.DirectCSIVolume{
@@ -998,6 +1021,29 @@ func TestAbnormalDeleteVolume(t1 *testing.T) {
 				StagingPath:   "/path/stagingpath",
 				ContainerPath: "/path/containerpath",
 				UsedCapacity:  int64(50),
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionStaged),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionPublished),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonNotInUse),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(directcsi.DirectCSIVolumeConditionReady),
+						Status:             metav1.ConditionTrue,
+						Message:            "",
+						Reason:             string(directcsi.DirectCSIVolumeReasonReady),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
 			},
 		},
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1003,10 +1003,10 @@ func TestAbnormalDeleteVolume(t1 *testing.T) {
 	}
 
 	deleteVolumeRequests := []csi.DeleteVolumeRequest{
-		csi.DeleteVolumeRequest{
+		{
 			VolumeId: "test-volume-1",
 		},
-		csi.DeleteVolumeRequest{
+		{
 			VolumeId: "test-volume-2",
 		},
 	}

--- a/pkg/node/stage_unstage.go
+++ b/pkg/node/stage_unstage.go
@@ -154,7 +154,6 @@ func (n *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 		}
 	}
 
-	vol.Status.HostPath = ""
 	vol.Status.StagingPath = ""
 	if _, err := directCSIClient.DirectCSIVolumes().Update(ctx, vol, metav1.UpdateOptions{
 		TypeMeta: utils.DirectCSIVolumeTypeMeta(),

--- a/pkg/node/stage_unstage_test.go
+++ b/pkg/node/stage_unstage_test.go
@@ -189,9 +189,6 @@ func TestStageUnstageVolume(t *testing.T) {
 	}
 
 	// Check if status fields were set correctly
-	if volObj.Status.HostPath != "" {
-		t.Errorf("Hostpath was not set to empty. Got: %v", volObj.Status.HostPath)
-	}
 	if volObj.Status.StagingPath != "" {
 		t.Errorf("StagingPath was not set to empty. Got: %v", volObj.Status.StagingPath)
 	}

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -105,3 +105,14 @@ func GetCondition(statusConditions []metav1.Condition, condType string) metav1.C
 	}
 	return metav1.Condition{}
 }
+
+func ExcludeFinalizer(finalizers []string, finalizer string) (result []string, found bool) {
+	for _, f := range finalizers {
+		if f != finalizer {
+			result = append(result, f)
+		} else {
+			found = true
+		}
+	}
+	return
+}


### PR DESCRIPTION
- Do not delete volumes if an abnormal delete is called on directcsivolume in use.
- Fix DeleteVolume RPC to not proceed if the volume hasn't been unstaged
- Fix deletion of PV directories upon deletion (FIX: Do not unset HostPath on NodeUnstageVolume RPC call)

Fixes https://github.com/minio/direct-csi/issues/323