### PR TITLE
Derive volume and drive object labels from its fields

### DIFF
--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -241,6 +241,14 @@ request:
 		t.Errorf("Error while converting %v", err)
 	}
 
+	if nodeLabelV := utils.GetLabelV(&directCSIVolume, utils.NodeLabel); nodeLabelV != directCSIVolume.Status.NodeName {
+		t.Errorf("expected node label value = %s, got = %s", directCSIVolume.Status.NodeName, nodeLabelV)
+	}
+
+	if createdByLabelV := utils.GetLabelV(&directCSIVolume, utils.CreatedByLabel); createdByLabelV != "directcsi-controller" {
+		t.Errorf("expected created-by label value = directcsi-controller, got = %s", createdByLabelV)
+	}
+
 	if !utils.IsCondition(directCSIVolume.Status.Conditions, string(directv1beta2.DirectCSIVolumeConditionReady), metav1.ConditionTrue, string(directv1beta2.DirectCSIVolumeReasonReady), "") {
 		t.Errorf("unexpected status.conditions = %v", directCSIVolume.Status.Conditions)
 	}
@@ -350,5 +358,21 @@ request:
 
 	if directCSIDrive.Status.PartitionUUID != "" {
 		t.Errorf("expected status.partitionUUID = \"\", actual status.partitionUUID = %v", directCSIDrive.Status.PartitionUUID)
+	}
+
+	if versionLabelV := utils.GetLabelV(&directCSIDrive, utils.VersionLabel); versionLabelV != "v1beta1" {
+		t.Errorf("expected version label value = v1beta1, got = %s", versionLabelV)
+	}
+
+	if nodeLabelV := utils.GetLabelV(&directCSIDrive, utils.NodeLabel); nodeLabelV != directCSIDrive.Status.NodeName {
+		t.Errorf("expected node label value = %s, got = %s", directCSIDrive.Status.NodeName, nodeLabelV)
+	}
+
+	if createdByLabelV := utils.GetLabelV(&directCSIDrive, utils.CreatedByLabel); createdByLabelV != "directcsi-driver" {
+		t.Errorf("expected created-by label value = directcsi-driver, got = %s", createdByLabelV)
+	}
+
+	if accessTierLabelV := utils.GetLabelV(&directCSIDrive, utils.AccessTierLabel); accessTierLabelV != string(directCSIDrive.Status.AccessTier) {
+		t.Errorf("expected access-tier label value = %s, got = %s", string(directCSIDrive.Status.AccessTier), accessTierLabelV)
 	}
 }

--- a/pkg/converter/drive_upgrade.go
+++ b/pkg/converter/drive_upgrade.go
@@ -18,10 +18,12 @@ package converter
 
 import (
 	"k8s.io/klog/v2"
+	"path/filepath"
 
 	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
 	directv1beta1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
 	directv1beta2 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta2"
+	"github.com/minio/direct-csi/pkg/utils"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -98,6 +100,12 @@ func driveUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) error
 	}
 
 	v1beta2DirectCSIDrive.TypeMeta = v1beta1DirectCSIDrive.TypeMeta
+	utils.UpdateLabels(&v1beta2DirectCSIDrive,
+		utils.NodeLabel, v1beta1DirectCSIDrive.Status.NodeName,
+		utils.DrivePathLabel, filepath.Base(v1beta1DirectCSIDrive.Status.Path),
+		utils.CreatedByLabel, "directcsi-driver",
+		utils.AccessTierLabel, string(v1beta1DirectCSIDrive.Status.AccessTier),
+	)
 
 	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&v1beta2DirectCSIDrive)
 	if err != nil {

--- a/pkg/converter/volume_upgrade.go
+++ b/pkg/converter/volume_upgrade.go
@@ -22,6 +22,7 @@ import (
 	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
 	directv1beta1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
 	directv1beta2 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta2"
+	"github.com/minio/direct-csi/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -130,6 +131,10 @@ func volumeUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) erro
 	}
 
 	v1beta2DirectCSIVolume.TypeMeta = v1beta1DirectCSIVolume.TypeMeta
+	utils.UpdateLabels(&v1beta2DirectCSIVolume,
+		utils.NodeLabel, v1beta2DirectCSIVolume.Status.NodeName,
+		utils.CreatedByLabel, "directcsi-controller",
+	)
 
 	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&v1beta2DirectCSIVolume)
 	if err != nil {

--- a/pkg/node/discovery/discovery.go
+++ b/pkg/node/discovery/discovery.go
@@ -188,11 +188,11 @@ func makeDirectCSIDrive(driveStatus directcsi.DirectCSIDriveStatus, driveName st
 		ObjectMeta: metav1.ObjectMeta{
 			Name: driveName,
 			Labels: map[string]string{
-				directcsi.Group + "/node":        driveStatus.NodeName,
-				directcsi.Group + "/path":        filepath.Base(driveStatus.Path),
-				directcsi.Group + "/version":     directcsi.Version,
-				directcsi.Group + "/created-by":  "directcsi-driver",
-				directcsi.Group + "/access-tier": string(driveStatus.AccessTier),
+				utils.NodeLabel:       driveStatus.NodeName,
+				utils.DrivePathLabel:  filepath.Base(driveStatus.Path),
+				utils.VersionLabel:    directcsi.Version,
+				utils.CreatedByLabel:  "directcsi-driver",
+				utils.AccessTierLabel: string(driveStatus.AccessTier),
 			},
 		},
 		Status: driveStatus,


### PR DESCRIPTION
As the identity label values like `direct-csi-min-io/Node` can be derived from its own status fields (eg, drive.Status.NodeName), the converter could always set the labels in the converted response.

As we are moving to more robust way to list objects by labels, this ensures the identity labels will always be present on the objects.

WIP: Testing and Adding test cases