### PR TITLE
Avoid block device verification during probing

### DIFF
--- a/pkg/node/discovery/utils.go
+++ b/pkg/node/discovery/utils.go
@@ -35,19 +35,24 @@ func (d *Discovery) verifyDriveMount(existingDrive *directcsi.DirectCSIDrive) er
 	driveMounter := &sys.DefaultDriveMounter{}
 	switch existingDrive.Status.DriveStatus {
 	case directcsi.DriveStatusInUse, directcsi.DriveStatusReady:
-		mountSource := sys.GetDirectCSIPath(existingDrive.Status.FilesystemUUID)
+		directCSIDevice := sys.GetDirectCSIPath(existingDrive.Status.FilesystemUUID)
+		// verify and fix the (major, minor) if it has changed
+		if err := sys.MakeBlockFile(directCSIDevice, existingDrive.Status.MajorNumber, existingDrive.Status.MinorNumber); err != nil {
+			return err
+		}
+
 		mountTarget := filepath.Join(sys.MountRoot, existingDrive.Status.FilesystemUUID)
 		// Check if the drive is mounted
 		isMounted := false
 		for _, mount := range d.mounts {
-			if mount.MountSource == mountSource {
+			if mount.MountSource == directCSIDevice {
 				isMounted = true
 				break
 			}
 		}
 		// Mount if umounted
 		if !isMounted {
-			if err := driveMounter.MountDrive(mountSource, mountTarget, []string{}); err != nil {
+			if err := driveMounter.MountDrive(directCSIDevice, mountTarget, []string{}); err != nil {
 				return err
 			}
 			existingDrive.Status.Mountpoint = mountTarget

--- a/pkg/sys/drive_discovery_linux.go
+++ b/pkg/sys/drive_discovery_linux.go
@@ -383,12 +383,6 @@ func (b *BlockDevice) probeBlockDev(ctx context.Context, driveMap map[string]*dr
 				FSBlockSize:   b.LogicalBlockSize,
 			}
 		}
-		if fsInfo.UUID != "" {
-			directCSIPath := GetDirectCSIPath(fsInfo.UUID)
-			if err := MakeBlockFile(directCSIPath, b.DriveInfo.Major, b.DriveInfo.Minor); err != nil {
-				return err
-			}
-		}
 		var mounts []MountInfo
 		mounts, err = b.probeMountInfo(b.DriveInfo.Major, b.DriveInfo.Minor, driveMap)
 		if err != nil {
@@ -415,14 +409,6 @@ func (b *BlockDevice) probeBlockDev(ctx context.Context, driveMap map[string]*dr
 				FSBlockSize:   p.LogicalBlockSize,
 			}
 		}
-
-		if fsInfo.UUID != "" {
-			directCSIPath := GetDirectCSIPath(fsInfo.UUID)
-			if err := MakeBlockFile(directCSIPath, p.DriveInfo.Major, p.DriveInfo.Minor); err != nil {
-				return err
-			}
-		}
-
 		var mounts []MountInfo
 		mounts, err = b.probeMountInfo(p.DriveInfo.Major, p.DriveInfo.Minor, driveMap)
 		if err != nil {


### PR DESCRIPTION
- Currently, we verify the directcsi block device during probing to check if the (major, minor) has changed during restarts and fix them.
- This PR will move that out from probing function, and verifies it before checking the drive mounts.