### PR TITLE
Move conversion deployment to direct-csi binary

### DIFF
--- a/cmd/direct-csi/cmd.go
+++ b/cmd/direct-csi/cmd.go
@@ -34,20 +34,18 @@ var Version string
 
 // flags
 var (
-	identity             = "direct-csi-min-io"
-	nodeID               = ""
-	rack                 = "default"
-	zone                 = "default"
-	region               = "default"
-	endpoint             = "unix://csi/csi.sock"
-	kubeconfig           = ""
-	controller           = false
-	driver               = false
-	procfs               = "/proc"
-	conversionWebhook    = false
-	conversionWebhookURL = ""
-	loopBackOnly         = false
-	showVersion          = false
+	identity     = "direct-csi-min-io"
+	nodeID       = ""
+	rack         = "default"
+	zone         = "default"
+	region       = "default"
+	endpoint     = "unix://csi/csi.sock"
+	kubeconfig   = ""
+	controller   = false
+	driver       = false
+	procfs       = "/proc"
+	loopBackOnly = false
+	showVersion  = false
 )
 
 var driverCmd = &cobra.Command{
@@ -68,8 +66,8 @@ For more information, use '%s man [sched | examples | ...]'
 		}
 
 		utils.Init()
-		if !controller && !driver && !conversionWebhook {
-			return fmt.Errorf("one among [--controller, --driver, --conversion-webhook] should be set")
+		if !controller && !driver {
+			return fmt.Errorf("one among [--controller, --driver] should be set")
 		}
 		return run(c.Context(), args)
 	},
@@ -103,8 +101,6 @@ func init() {
 	driverCmd.Flags().StringVarP(&procfs, "procfs", "", procfs, "path to host /proc for accessing mount information")
 	driverCmd.Flags().BoolVarP(&controller, "controller", "", controller, "running in controller mode")
 	driverCmd.Flags().BoolVarP(&driver, "driver", "", driver, "run in driver mode")
-	driverCmd.Flags().BoolVarP(&conversionWebhook, "conversion-webhook", "", conversionWebhook, "start and serve conversion webhook")
-	driverCmd.Flags().StringVarP(&conversionWebhookURL, "conversion-webhook-url", "", conversionWebhookURL, "The URL of the conversion webhook")
 	driverCmd.Flags().BoolVarP(&loopBackOnly, "loopback-only", "", loopBackOnly, "Create and uses loopback devices only")
 
 	driverCmd.PersistentFlags().MarkHidden("alsologtostderr")

--- a/cmd/direct-csi/cmd.go
+++ b/cmd/direct-csi/cmd.go
@@ -34,18 +34,19 @@ var Version string
 
 // flags
 var (
-	identity     = "direct-csi-min-io"
-	nodeID       = ""
-	rack         = "default"
-	zone         = "default"
-	region       = "default"
-	endpoint     = "unix://csi/csi.sock"
-	kubeconfig   = ""
-	controller   = false
-	driver       = false
-	procfs       = "/proc"
-	loopBackOnly = false
-	showVersion  = false
+	identity             = "direct-csi-min-io"
+	nodeID               = ""
+	rack                 = "default"
+	zone                 = "default"
+	region               = "default"
+	endpoint             = "unix://csi/csi.sock"
+	kubeconfig           = ""
+	controller           = false
+	driver               = false
+	procfs               = "/proc"
+	loopBackOnly         = false
+	showVersion          = false
+	conversionHealthzURL = ""
 )
 
 var driverCmd = &cobra.Command{
@@ -102,6 +103,7 @@ func init() {
 	driverCmd.Flags().BoolVarP(&controller, "controller", "", controller, "running in controller mode")
 	driverCmd.Flags().BoolVarP(&driver, "driver", "", driver, "run in driver mode")
 	driverCmd.Flags().BoolVarP(&loopBackOnly, "loopback-only", "", loopBackOnly, "Create and uses loopback devices only")
+	driverCmd.Flags().StringVarP(&conversionHealthzURL, "conversion-healthz-url", "", conversionHealthzURL, "The URL of the conversion webhook healthz endpoint")
 
 	driverCmd.PersistentFlags().MarkHidden("alsologtostderr")
 	driverCmd.PersistentFlags().MarkHidden("log_backtrace_at")

--- a/cmd/direct-csi/run.go
+++ b/cmd/direct-csi/run.go
@@ -34,18 +34,16 @@ import (
 
 func run(ctx context.Context, args []string) error {
 
-	go func() {
-		// Start conversion webserver
-		if err := converter.ServeConversionWebhook(ctx); err != nil {
-			klog.V(3).Infof("Stopped serving conversion webhook: %v", err)
-		}
-	}()
+	// Start conversion webserver
+	if err := converter.ServeConversionWebhook(ctx); err != nil {
+		klog.V(3).Infof("Stopped serving conversion webhook: %v", err)
+	}
 
 	idServer, err := id.NewIdentityServer(identity, Version, map[string]string{})
 	if err != nil {
 		return err
 	}
-	klog.V(5).Infof("identity server started")
+	klog.V(3).Infof("identity server started")
 
 	var nodeSrv csi.NodeServer
 	if driver {

--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -143,37 +143,6 @@ func install(ctx context.Context, args []string) error {
 		klog.Infof("crds successfully registered")
 	}
 
-	// if dryRun {
-	// 	// if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
-	// 	// 	return err
-	// 	// }
-	// 	if err := registerCRDs(ctx, identity, apiextensions.WebhookConverter); err != nil {
-	// 		if !k8serrors.IsAlreadyExists(err) {
-	// 			return err
-	// 		}
-	// 	}
-	// } else {
-	// 	if err := registerCRDs(ctx, identity, apiextensions.NoneConverter); err != nil {
-	// 		if !k8serrors.IsAlreadyExists(err) {
-	// 			return err
-	// 		}
-	// 	}
-	// 	klog.Infof("crds successfully registered")
-
-	// 	if err := syncCRDObjects(ctx); err != nil {
-	// 		return err
-	// 	}
-
-	// 	if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
-	// 		return err
-	// 	}
-	// 	klog.Infof("'%s' conversion deployment created", utils.Bold(identity))
-
-	// 	if err := updateConversionWebhookOnCRDs(ctx, identity); err != nil {
-	// 		return err
-	// 	}
-	// }
-
 	if err := installer.CreateCSIDriver(ctx, identity, dryRun); err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err

--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -28,7 +28,6 @@ import (
 	"github.com/minio/direct-csi/pkg/installer"
 	"github.com/minio/direct-csi/pkg/utils"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -134,7 +133,7 @@ func install(ctx context.Context, args []string) error {
 		klog.Infof("'%s' conversion webhook secrets created", utils.Bold(identity))
 	}
 
-	if err := registerCRDs(ctx, identity, apiextensions.WebhookConverter); err != nil {
+	if err := registerCRDs(ctx, identity); err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}

--- a/cmd/kubectl-direct_csi/install.go
+++ b/cmd/kubectl-direct_csi/install.go
@@ -119,36 +119,60 @@ func install(ctx context.Context, args []string) error {
 		klog.Infof("'%s' rbac roles created", utils.Bold(identity))
 	}
 
-	if dryRun {
-		if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
-			return err
-		}
-		if err := registerCRDs(ctx, identity, apiextensions.WebhookConverter); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
-				return err
-			}
-		}
-	} else {
-		if err := registerCRDs(ctx, identity, apiextensions.NoneConverter); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
-				return err
-			}
-		}
-		klog.Infof("crds successfully registered")
-
-		if err := syncCRDObjects(ctx); err != nil {
-			return err
-		}
-
-		if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
-			return err
-		}
-		klog.Infof("'%s' conversion deployment created", utils.Bold(identity))
-
-		if err := updateConversionWebhookOnCRDs(ctx, identity); err != nil {
+	if !dryRun {
+		if err := installer.DeleteLegacyConversionDeployment(ctx, identity); err != nil {
 			return err
 		}
 	}
+
+	if err := installer.CreateConversionWebhookSecrets(ctx, identity, dryRun); err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	if !dryRun {
+		klog.Infof("'%s' conversion webhook secrets created", utils.Bold(identity))
+	}
+
+	if err := registerCRDs(ctx, identity, apiextensions.WebhookConverter); err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	if !dryRun {
+		klog.Infof("crds successfully registered")
+	}
+
+	// if dryRun {
+	// 	// if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
+	// 	// 	return err
+	// 	// }
+	// 	if err := registerCRDs(ctx, identity, apiextensions.WebhookConverter); err != nil {
+	// 		if !k8serrors.IsAlreadyExists(err) {
+	// 			return err
+	// 		}
+	// 	}
+	// } else {
+	// 	if err := registerCRDs(ctx, identity, apiextensions.NoneConverter); err != nil {
+	// 		if !k8serrors.IsAlreadyExists(err) {
+	// 			return err
+	// 		}
+	// 	}
+	// 	klog.Infof("crds successfully registered")
+
+	// 	if err := syncCRDObjects(ctx); err != nil {
+	// 		return err
+	// 	}
+
+	// 	if err := installer.CreateOrUpdateConversionDeployment(ctx, identity, image, dryRun, registry, org); err != nil {
+	// 		return err
+	// 	}
+	// 	klog.Infof("'%s' conversion deployment created", utils.Bold(identity))
+
+	// 	if err := updateConversionWebhookOnCRDs(ctx, identity); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	if err := installer.CreateCSIDriver(ctx, identity, dryRun); err != nil {
 		if !k8serrors.IsAlreadyExists(err) {

--- a/cmd/kubectl-direct_csi/register.go
+++ b/cmd/kubectl-direct_csi/register.go
@@ -196,7 +196,7 @@ func setConversionWebhook(ctx context.Context, crdObj *apiextensions.CustomResou
 				panic("unknown crd name found")
 			}
 		}()
-		port := int32(30443)
+		port := int32(installer.ConversionWebhookPort)
 
 		return &apiextensions.ServiceReference{
 			Namespace: name,

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -218,16 +218,6 @@ func uninstall(ctx context.Context, args []string) error {
 	}
 	klog.Infof("'%s' conversion secrets deleted", utils.Bold(identity))
 
-	// if err := installer.DeleteConversionSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
-	// 	return err
-	// }
-
-	// if err := installer.DeleteConversionWebhookCertsSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
-	// 	return err
-	// }
-
-	// klog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
-
 	if err := installer.DeleteNamespace(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -213,19 +213,20 @@ func uninstall(ctx context.Context, args []string) error {
 	}
 	klog.Infof("'%s' controller deployment deleted", utils.Bold(identity))
 
-	if err := installer.DeleteConversionDeployment(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
+	if err := installer.DeleteConversionSecrets(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
+	klog.Infof("'%s' conversion secrets deleted", utils.Bold(identity))
 
-	if err := installer.DeleteConversionSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
+	// if err := installer.DeleteConversionSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
+	// 	return err
+	// }
 
-	if err := installer.DeleteConversionWebhookCertsSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
+	// if err := installer.DeleteConversionWebhookCertsSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
+	// 	return err
+	// }
 
-	klog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
+	// klog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
 
 	if err := installer.DeleteNamespace(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
 		return err

--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -213,6 +213,10 @@ func uninstall(ctx context.Context, args []string) error {
 	}
 	klog.Infof("'%s' controller deployment deleted", utils.Bold(identity))
 
+	if err := installer.DeleteLegacyConversionDeployment(ctx, identity); err != nil {
+		return err
+	}
+
 	if err := installer.DeleteConversionSecrets(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/cmd/kubectl-direct_csi/utils.go
+++ b/cmd/kubectl-direct_csi/utils.go
@@ -29,12 +29,8 @@ import (
 	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta2"
 	clientset "github.com/minio/direct-csi/pkg/clientset/typed/direct.csi.min.io/v1beta2"
 	"github.com/minio/direct-csi/pkg/sys"
-	"k8s.io/client-go/util/retry"
 
-	"github.com/minio/direct-csi/pkg/converter"
 	"github.com/minio/direct-csi/pkg/utils"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,185 +112,6 @@ func canonicalNameFromPath(val string) string {
 	return strings.ReplaceAll(dr, directCSIPartitionInfix, "")
 }
 
-func syncCRDObjects(ctx context.Context) error {
-	crdClient := utils.GetCRDClient()
-
-	supportedCRDs := []string{
-		driveCRDName,
-		volumeCRDName,
-	}
-	for _, crdName := range supportedCRDs {
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			crd, err := crdClient.Get(ctx, crdName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-
-			v := utils.GetLabelV(crd, utils.VersionLabel)
-			if v == string(directcsi.Version) {
-				// already upgraded to latest
-				return nil
-			}
-
-			if err := syncObjects(ctx, crd); err != nil {
-				return err
-			}
-
-			utils.SetLabelKV(crd, utils.VersionLabel, directcsi.Version)
-			if _, err := crdClient.Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func syncObjects(ctx context.Context, crd *apiextensions.CustomResourceDefinition) error {
-	storedVersions := crd.Status.StoredVersions
-	if len(storedVersions) == 0 {
-		// No objects stored
-		return nil
-	}
-
-	if len(storedVersions) == 1 && storedVersions[0] == string(directcsi.Version) {
-		// already latest
-		return nil
-	}
-
-	info, err := utils.GetGroupKindVersions(directcsi.Group, crd.Spec.Names.Kind, "v1beta1", "v1alpha1")
-	if err != nil {
-		return err
-	}
-	fromVersion := info.Version
-
-	migrateFn := func() migrateFunc {
-		switch crd.Name {
-		case driveCRDName:
-			return migrateDriveObjects
-		case volumeCRDName:
-			return migrateVolumeObjects
-		default:
-			fn := func(_ context.Context, _ string) error {
-				return fmt.Errorf("Unsupported crd: %v", crd.Name)
-			}
-			return fn
-		}
-	}()
-	if err := migrateFn(ctx, fromVersion); err != nil {
-		return err
-	}
-
-	klog.Infof("'%s' objects successfully synced", utils.Bold(crd.Name))
-	return nil
-}
-
-func toUnstructured(obj interface{}) (unstructured.Unstructured, error) {
-	unstructured := unstructured.Unstructured{}
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		return unstructured, err
-	}
-	unstructured.Object = unstructuredObj
-	return unstructured, nil
-}
-
-func migrateDriveObjects(ctx context.Context, fromVersion string) error {
-	directCSIClient := utils.GetDirectCSIClient()
-	ctx, cancelFunc := context.WithCancel(ctx)
-	defer cancelFunc()
-
-	resultCh, err := utils.ListDrives(ctx, directCSIClient.DirectCSIDrives(), nil, nil, nil, utils.MaxThreadCount)
-	if err != nil {
-		return err
-	}
-
-	return processDrives(
-		ctx,
-		resultCh,
-		func(drive *directcsi.DirectCSIDrive) bool {
-			return true
-		},
-		func(drive *directcsi.DirectCSIDrive) error {
-			return nil
-		},
-		func(ctx context.Context, drive *directcsi.DirectCSIDrive) error {
-			unstructured, err := toUnstructured(drive)
-			if err != nil {
-				klog.V(4).Infof("Error while syncing directcsidrive [%v]: %v", unstructured.GetName(), err)
-				return nil
-			}
-			unstructured.SetAPIVersion(strings.Join([]string{directcsi.Group, fromVersion}, "/"))
-			if err := converter.Migrate(&unstructured, strings.Join([]string{directcsi.Group, directcsi.Version}, "/")); err != nil {
-				klog.V(4).Infof("Error while syncing directcsidrive [%v]: %v", unstructured.GetName(), err)
-				return nil
-			}
-			var updatedDrive directcsi.DirectCSIDrive
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &updatedDrive); err != nil {
-				klog.V(4).Infof("Error while syncing directcsidrive [%v]: %v", unstructured.GetName(), err)
-				return nil
-			}
-
-			_, err = directCSIClient.DirectCSIDrives().Update(ctx, &updatedDrive, metav1.UpdateOptions{
-				TypeMeta: utils.DirectCSIDriveTypeMeta(),
-			})
-			if err != nil {
-				klog.V(4).Infof("Error while syncing directcsidrive [%v]: %v", unstructured.GetName(), err)
-			}
-			return nil
-		},
-	)
-}
-
-func migrateVolumeObjects(ctx context.Context, fromVersion string) error {
-	directCSIClient := utils.GetDirectCSIClient()
-	ctx, cancelFunc := context.WithCancel(ctx)
-	defer cancelFunc()
-
-	resultCh, err := utils.ListVolumes(ctx, directCSIClient.DirectCSIVolumes(), nil, nil, nil, nil, utils.MaxThreadCount)
-	if err != nil {
-		return err
-	}
-
-	return processVolumes(
-		ctx,
-		resultCh,
-		func(volume *directcsi.DirectCSIVolume) bool {
-			return true
-		},
-		func(volume *directcsi.DirectCSIVolume) error {
-			return nil
-		},
-		func(ctx context.Context, volume *directcsi.DirectCSIVolume) error {
-			unstructured, err := toUnstructured(volume)
-			if err != nil {
-				klog.V(4).Infof("Error while syncing directcsivolume [%v]: %v", unstructured.GetName(), err)
-				return nil
-			}
-			unstructured.SetAPIVersion(strings.Join([]string{directcsi.Group, fromVersion}, "/"))
-			if err := converter.Migrate(&unstructured, strings.Join([]string{directcsi.Group, directcsi.Version}, "/")); err != nil {
-				klog.V(4).Infof("Error while syncing directcsivolume [%v]: %v", unstructured.GetName(), err)
-				return nil
-			}
-			var updatedVolume directcsi.DirectCSIVolume
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &updatedVolume); err != nil {
-				klog.V(4).Infof("Error while syncing directcsivolume [%v]: %v", unstructured.GetName(), err)
-				return nil
-			}
-
-			_, err = directCSIClient.DirectCSIVolumes().Update(ctx, &updatedVolume, metav1.UpdateOptions{
-				TypeMeta: utils.DirectCSIVolumeTypeMeta(),
-			})
-			if err != nil {
-				klog.V(4).Infof("Error while syncing directcsivolume [%v]: %v", unstructured.GetName(), err)
-			}
-			return nil
-		},
-	)
-}
-
 func getFilteredDriveList(ctx context.Context, driveInterface clientset.DirectCSIDriveInterface, filterFunc func(directcsi.DirectCSIDrive) bool) ([]directcsi.DirectCSIDrive, error) {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
@@ -307,7 +124,7 @@ func getFilteredDriveList(ctx context.Context, driveInterface clientset.DirectCS
 	filteredDrives := []directcsi.DirectCSIDrive{}
 	for result := range resultCh {
 		if result.Err != nil {
-			return nil, err
+			return nil, result.Err
 		}
 
 		if filterFunc(result.Drive) {

--- a/pkg/controller/admission_controller.go
+++ b/pkg/controller/admission_controller.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	port              = "30443"
+	port              = "20443"
 	certPath          = "/etc/certs/cert.pem"
 	keyPath           = "/etc/certs/key.pem"
 	driveHandlerPath  = "/validatedrive"

--- a/pkg/controller/admission_controller.go
+++ b/pkg/controller/admission_controller.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	port              = "20443"
-	certPath          = "/etc/certs/cert.pem"
-	keyPath           = "/etc/certs/key.pem"
+	certPath          = "/etc/admission/certs/cert.pem"
+	keyPath           = "/etc/admission/certs/key.pem"
 	driveHandlerPath  = "/validatedrive"
 	volumeHandlerPath = "/validatevolume"
 )

--- a/pkg/controller/admission_controller.go
+++ b/pkg/controller/admission_controller.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	port              = "443"
+	port              = "30443"
 	certPath          = "/etc/certs/cert.pem"
 	keyPath           = "/etc/certs/key.pem"
 	driveHandlerPath  = "/validatedrive"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -75,7 +75,7 @@ import (
 
 func NewControllerServer(ctx context.Context, identity, nodeID, rack, zone, region string) (*ControllerServer, error) {
 	// Start admission webhook server
-	go serveAdmissionController(ctx)
+	// go serveAdmissionController(ctx)
 
 	config, err := utils.GetKubeConfig()
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -75,7 +75,7 @@ import (
 
 func NewControllerServer(ctx context.Context, identity, nodeID, rack, zone, region string) (*ControllerServer, error) {
 	// Start admission webhook server
-	// go serveAdmissionController(ctx)
+	go serveAdmissionController(ctx)
 
 	config, err := utils.GetKubeConfig()
 	if err != nil {

--- a/pkg/converter/drive_downgrade.go
+++ b/pkg/converter/drive_downgrade.go
@@ -36,7 +36,7 @@ func downgradeDriveObject(fromVersion, toVersion string, convertedObject *unstru
 		fallthrough
 	case versionV1Beta1:
 		if toVersion == versionV1Beta1 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 		if err := driveDowngradeV1Beta1ToV1alpha1(convertedObject); err != nil {
@@ -45,7 +45,7 @@ func downgradeDriveObject(fromVersion, toVersion string, convertedObject *unstru
 		fallthrough
 	case versionV1Alpha1:
 		if toVersion == versionV1Alpha1 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 	}
@@ -61,7 +61,7 @@ func driveDowngradeV1Beta1ToV1alpha1(unstructured *unstructured.Unstructured) er
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsidrive: %v to v1alpha1", v1beta1DirectCSIDrive.Name)
+	klog.V(10).Infof("Converting directcsidrive: %v to v1alpha1", v1beta1DirectCSIDrive.Name)
 
 	var v1alpha1DirectCSIDrive directv1alpha1.DirectCSIDrive
 	if err := directv1beta1.Convert_v1beta1_DirectCSIDrive_To_v1alpha1_DirectCSIDrive(&v1beta1DirectCSIDrive, &v1alpha1DirectCSIDrive, nil); err != nil {
@@ -87,7 +87,7 @@ func driveDowngradeV1Beta2ToV1Beta1(unstructured *unstructured.Unstructured) err
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsidrive: %v to v1beta1", v1beta2DirectCSIDrive.Name)
+	klog.V(10).Infof("Converting directcsidrive: %v to v1beta1", v1beta2DirectCSIDrive.Name)
 
 	var v1beta1DirectCSIDrive directv1beta1.DirectCSIDrive
 	if err := directv1beta2.Convert_v1beta2_DirectCSIDrive_To_v1beta1_DirectCSIDrive(&v1beta2DirectCSIDrive, &v1beta1DirectCSIDrive, nil); err != nil {

--- a/pkg/converter/drive_upgrade.go
+++ b/pkg/converter/drive_upgrade.go
@@ -38,7 +38,7 @@ func upgradeDriveObject(fromVersion, toVersion string, convertedObject *unstruct
 		fallthrough
 	case versionV1Beta1:
 		if toVersion == versionV1Beta1 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 		if err := driveUpgradeV1Beta1ToV1Beta2(convertedObject); err != nil {
@@ -47,7 +47,7 @@ func upgradeDriveObject(fromVersion, toVersion string, convertedObject *unstruct
 		fallthrough
 	case versionV1Beta2:
 		if toVersion == versionV1Beta2 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 	}
@@ -64,7 +64,7 @@ func driveUpgradeV1alpha1ToV1Beta1(unstructured *unstructured.Unstructured) erro
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsidrive: %v to v1beta1", v1alpha1DirectCSIDrive.Name)
+	klog.V(10).Infof("Converting directcsidrive: %v to v1beta1", v1alpha1DirectCSIDrive.Name)
 
 	var v1beta1DirectCSIDrive directv1beta1.DirectCSIDrive
 	if err := directv1beta1.Convert_v1alpha1_DirectCSIDrive_To_v1beta1_DirectCSIDrive(&v1alpha1DirectCSIDrive, &v1beta1DirectCSIDrive, nil); err != nil {
@@ -92,7 +92,7 @@ func driveUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) error
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsidrive: %v to v1beta2", v1beta1DirectCSIDrive.Name)
+	klog.V(10).Infof("Converting directcsidrive: %v to v1beta2", v1beta1DirectCSIDrive.Name)
 
 	var v1beta2DirectCSIDrive directv1beta2.DirectCSIDrive
 	if err := directv1beta2.Convert_v1beta1_DirectCSIDrive_To_v1beta2_DirectCSIDrive(&v1beta1DirectCSIDrive, &v1beta2DirectCSIDrive, nil); err != nil {

--- a/pkg/converter/volume_downgrade.go
+++ b/pkg/converter/volume_downgrade.go
@@ -36,7 +36,7 @@ func downgradeVolumeObject(fromVersion, toVersion string, convertedObject *unstr
 		fallthrough
 	case versionV1Beta1:
 		if toVersion == versionV1Beta1 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 		if err := volumeDowngradeV1Beta1ToV1alpha1(convertedObject); err != nil {
@@ -45,7 +45,7 @@ func downgradeVolumeObject(fromVersion, toVersion string, convertedObject *unstr
 		fallthrough
 	case versionV1Alpha1:
 		if toVersion == versionV1Alpha1 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 	}
@@ -61,7 +61,7 @@ func volumeDowngradeV1Beta1ToV1alpha1(unstructured *unstructured.Unstructured) e
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsivolume: %v to v1alpha1", v1beta1DirectCSIVolume.Name)
+	klog.V(10).Infof("Converting directcsivolume: %v to v1alpha1", v1beta1DirectCSIVolume.Name)
 
 	var v1alpha1DirectCSIVolume directv1alpha1.DirectCSIVolume
 	if err := directv1beta1.Convert_v1beta1_DirectCSIVolume_To_v1alpha1_DirectCSIVolume(&v1beta1DirectCSIVolume, &v1alpha1DirectCSIVolume, nil); err != nil {
@@ -87,7 +87,7 @@ func volumeDowngradeV1Beta2ToV1Beta1(unstructured *unstructured.Unstructured) er
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsivolume: %v to v1beta1", v1beta2DirectCSIVolume.Name)
+	klog.V(10).Infof("Converting directcsivolume: %v to v1beta1", v1beta2DirectCSIVolume.Name)
 
 	var v1beta1DirectCSIVolume directv1beta1.DirectCSIVolume
 	if err := directv1beta2.Convert_v1beta2_DirectCSIVolume_To_v1beta1_DirectCSIVolume(&v1beta2DirectCSIVolume, &v1beta1DirectCSIVolume, nil); err != nil {

--- a/pkg/converter/volume_upgrade.go
+++ b/pkg/converter/volume_upgrade.go
@@ -38,7 +38,7 @@ func upgradeVolumeObject(fromVersion, toVersion string, convertedObject *unstruc
 		fallthrough
 	case versionV1Beta1:
 		if toVersion == versionV1Beta1 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 		if err := volumeUpgradeV1Beta1ToV1Beta2(convertedObject); err != nil {
@@ -47,7 +47,7 @@ func upgradeVolumeObject(fromVersion, toVersion string, convertedObject *unstruc
 		fallthrough
 	case versionV1Beta2:
 		if toVersion == versionV1Beta2 {
-			klog.V(2).Info("Successfully migrated")
+			klog.V(10).Info("Successfully migrated")
 			break
 		}
 	}
@@ -65,7 +65,7 @@ func volumeUpgradeV1alpha1ToV1Beta1(unstructured *unstructured.Unstructured) err
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsivolume:%v volume to v1beta1", v1alpha1DirectCSIVolume.Name)
+	klog.V(10).Infof("Converting directcsivolume:%v volume to v1beta1", v1alpha1DirectCSIVolume.Name)
 
 	var v1beta1DirectCSIVolume directv1beta1.DirectCSIVolume
 	if err := directv1beta1.Convert_v1alpha1_DirectCSIVolume_To_v1beta1_DirectCSIVolume(&v1alpha1DirectCSIVolume, &v1beta1DirectCSIVolume, nil); err != nil {
@@ -123,7 +123,7 @@ func volumeUpgradeV1Beta1ToV1Beta2(unstructured *unstructured.Unstructured) erro
 		return err
 	}
 
-	klog.V(4).Infof("Converting directcsivolume:%v to v1beta2", v1beta1DirectCSIVolume.Name)
+	klog.V(10).Infof("Converting directcsivolume:%v to v1beta2", v1beta1DirectCSIVolume.Name)
 
 	var v1beta2DirectCSIVolume directv1beta2.DirectCSIVolume
 	if err := directv1beta2.Convert_v1beta1_DirectCSIVolume_To_v1beta2_DirectCSIVolume(&v1beta1DirectCSIVolume, &v1beta2DirectCSIVolume, nil); err != nil {

--- a/pkg/converter/webhook.go
+++ b/pkg/converter/webhook.go
@@ -63,18 +63,19 @@ func ServeConversionWebhook(ctx context.Context) error {
 		return lErr
 	}
 
-	klog.V(2).Infof("Starting conversion webhook server in port: %s", port)
-	if err := server.ServeTLS(listener, "", ""); err != nil {
-		klog.Errorf("Failed to listen and serve conversion webhook server: %v", err)
-		return err
-	}
+	go func() {
+		klog.V(2).Infof("Starting conversion webhook server in port: %s", port)
+		if err := server.ServeTLS(listener, "", ""); err != nil {
+			klog.Errorf("Failed to listen and serve conversion webhook server: %v", err)
+		}
+	}()
 
 	return nil
 }
 
 // LivenessCheckHandler - Checks if the process is up. Always returns success.
 func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
-	klog.V(5).Infof("Liveness check request: %v", r)
+	klog.Infof("Liveness check request: %v", r)
 	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/pkg/converter/webhook.go
+++ b/pkg/converter/webhook.go
@@ -64,7 +64,7 @@ func ServeConversionWebhook(ctx context.Context) error {
 	}
 
 	go func() {
-		klog.V(2).Infof("Starting conversion webhook server in port: %s", port)
+		klog.V(3).Infof("Starting conversion webhook server in port: %s", port)
 		if err := server.ServeTLS(listener, "", ""); err != nil {
 			klog.Errorf("Failed to listen and serve conversion webhook server: %v", err)
 		}

--- a/pkg/converter/webhook.go
+++ b/pkg/converter/webhook.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	port              = "30443"
-	certPath          = "/etc/certs/cert.pem"
-	keyPath           = "/etc/certs/key.pem"
+	certPath          = "/etc/conversion/certs/cert.pem"
+	keyPath           = "/etc/conversion/certs/key.pem"
 	DriveHandlerPath  = "/convertdrive"
 	VolumeHandlerPath = "/convertvolume"
 	healthzPath       = "/healthz"
@@ -75,7 +75,7 @@ func ServeConversionWebhook(ctx context.Context) error {
 
 // LivenessCheckHandler - Checks if the process is up. Always returns success.
 func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
-	klog.Infof("Liveness check request: %v", r)
+	klog.V(5).Infof("Liveness check request: %v", r)
 	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/pkg/converter/webhook.go
+++ b/pkg/converter/webhook.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	port              = "443"
+	port              = "30443"
 	certPath          = "/etc/certs/cert.pem"
 	keyPath           = "/etc/certs/key.pem"
 	DriveHandlerPath  = "/convertdrive"

--- a/pkg/drive/drive.go
+++ b/pkg/drive/drive.go
@@ -113,7 +113,7 @@ func (handler *DriveEventHandler) getFSUUID(ctx context.Context, drive *directcs
 
 	for result := range resultCh {
 		if result.Err != nil {
-			return "", err
+			return "", result.Err
 		}
 
 		if result.Drive.Name != drive.Name && result.Drive.Status.FilesystemUUID == drive.Status.FilesystemUUID {

--- a/pkg/installer/const.go
+++ b/pkg/installer/const.go
@@ -90,7 +90,7 @@ const (
 	validationControllerName       = "directcsi-validation-controller"
 	admissionControllerWebhookName = "validatinghook"
 	ValidationWebhookConfigName    = "drive.validation.controller"
-	admissionControllerWebhookPort = 443
+	admissionControllerWebhookPort = 30443
 	certsDir                       = "/etc/certs"
 	admissionWehookDNSName         = "directcsi-validation-controller.direct-csi-min-io.svc"
 	privateKeyFileName             = "key.pem"
@@ -103,7 +103,7 @@ const (
 	conversionWebhookName                  = "directcsi-conversion-webhook"
 	ConversionWebhookSecretName            = "conversionwebhookcerts"
 	conversionWebhookPortName              = "convwebhook"
-	conversionWebhookPort                  = 443
+	conversionWebhookPort                  = 30443
 	conversionDeploymentReadinessThreshold = 2
 	conversionDeploymentRetryInterval      = 3 * time.Second
 
@@ -111,4 +111,9 @@ const (
 	conversionWebhookCertsSecret = "converionwebhookcertsecret"
 	caCertFileName               = "ca.pem"
 	caDir                        = "/etc/CAs"
+
+	// conversion
+	conversionKeyPair           = "conversionkeypair"
+	conversionCACert            = "conversioncacert"
+	conversionKeyPairVolumeName = "conversionkeypair"
 )

--- a/pkg/installer/const.go
+++ b/pkg/installer/const.go
@@ -16,10 +16,6 @@
 
 package installer
 
-import (
-	"time"
-)
-
 // CSI provisioner images
 const (
 	// quay.io/minio/csi-provisioner:v2.2.0-go1.17
@@ -90,7 +86,7 @@ const (
 	validationControllerName       = "directcsi-validation-controller"
 	admissionControllerWebhookName = "validatinghook"
 	ValidationWebhookConfigName    = "drive.validation.controller"
-	admissionControllerWebhookPort = 30443
+	admissionControllerWebhookPort = 20443
 	certsDir                       = "/etc/certs"
 	admissionWehookDNSName         = "directcsi-validation-controller.direct-csi-min-io.svc"
 	privateKeyFileName             = "key.pem"
@@ -99,21 +95,16 @@ const (
 	// Finalizers
 	DirectCSIFinalizerDeleteProtection = "/delete-protection"
 
-	// Conversion webhook
-	conversionWebhookName                  = "directcsi-conversion-webhook"
-	ConversionWebhookSecretName            = "conversionwebhookcerts"
-	conversionWebhookPortName              = "convwebhook"
-	conversionWebhookPort                  = 30443
-	conversionDeploymentReadinessThreshold = 2
-	conversionDeploymentRetryInterval      = 3 * time.Second
-
-	conversionWebhookCertVolume  = "conversion-webhook-certs"
-	conversionWebhookCertsSecret = "converionwebhookcertsecret"
-	caCertFileName               = "ca.pem"
-	caDir                        = "/etc/CAs"
+	// Conversion webhook (Legacy)
+	conversionWebhookDeploymentName = "directcsi-conversion-webhook"
+	ConversionWebhookSecretName     = "conversionwebhookcerts"
+	conversionWebhookCertsSecret    = "converionwebhookcertsecret"
 
 	// conversion
 	conversionKeyPair           = "conversionkeypair"
 	conversionCACert            = "conversioncacert"
 	conversionKeyPairVolumeName = "conversionkeypair"
+	conversionWebhookPortName   = "convwebhook"
+	ConversionWebhookPort       = 30443
+	caCertFileName              = "ca.pem"
 )

--- a/pkg/installer/const.go
+++ b/pkg/installer/const.go
@@ -48,6 +48,7 @@ const (
 	clusterRoleVerbDelete = "delete"
 	clusterRoleVerbUpdate = "update"
 	clusterRoleVerbPatch  = "patch"
+	selectorValueEnabled  = "enabled"
 
 	volumeNameSocketDir       = "socket-dir"
 	volumeNameDevDir          = "dev-dir"
@@ -87,7 +88,7 @@ const (
 	admissionControllerWebhookName = "validatinghook"
 	ValidationWebhookConfigName    = "drive.validation.controller"
 	admissionControllerWebhookPort = 20443
-	certsDir                       = "/etc/certs"
+	admissionCertsDir              = "/etc/admission/certs"
 	admissionWehookDNSName         = "directcsi-validation-controller.direct-csi-min-io.svc"
 	privateKeyFileName             = "key.pem"
 	publicCertFileName             = "cert.pem"
@@ -101,10 +102,12 @@ const (
 	conversionWebhookCertsSecret    = "converionwebhookcertsecret"
 
 	// conversion
-	conversionKeyPair           = "conversionkeypair"
-	conversionCACert            = "conversioncacert"
-	conversionKeyPairVolumeName = "conversionkeypair"
-	conversionWebhookPortName   = "convwebhook"
-	ConversionWebhookPort       = 30443
-	caCertFileName              = "ca.pem"
+	conversionKeyPair         = "conversionkeypair"
+	conversionCACert          = "conversioncacert"
+	conversionWebhookPortName = "convwebhook"
+	ConversionWebhookPort     = 30443
+	caCertFileName            = "ca.pem"
+	conversionCADir           = "/etc/conversion/CAs"
+	conversionCertsDir        = "/etc/conversion/certs"
+	webhookSelector           = "selector.direct.csi.min.io.webhook"
 )

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -998,10 +998,8 @@ func checkConversionSecrets(ctx context.Context, identity string) error {
 	if _, err := secretsClient.Get(ctx, conversionKeyPair, metav1.GetOptions{}); err != nil {
 		return err
 	}
-	if _, err := secretsClient.Get(ctx, conversionCACert, metav1.GetOptions{}); err != nil {
-		return err
-	}
-	return nil
+	_, err := secretsClient.Get(ctx, conversionCACert, metav1.GetOptions{})
+	return err
 }
 
 func CreateConversionWebhookSecrets(ctx context.Context, identity string, dryRun bool) error {
@@ -1023,9 +1021,6 @@ func CreateConversionWebhookSecrets(ctx context.Context, identity string, dryRun
 	if err := CreateOrUpdateConversionKeyPairSecret(ctx, identity, publicCertBytes, privateKeyBytes, dryRun); err != nil {
 		return err
 	}
-	if err := CreateOrUpdateConversionCACertSecret(ctx, identity, caCertBytes, dryRun); err != nil {
-		return err
-	}
 
-	return nil
+	return CreateOrUpdateConversionCACertSecret(ctx, identity, caCertBytes, dryRun)
 }

--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -186,10 +186,7 @@ func DeleteConversionSecrets(ctx context.Context, identity string) error {
 	if err := secretsClient.Delete(ctx, conversionKeyPair, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if err := secretsClient.Delete(ctx, conversionCACert, metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-	return nil
+	return secretsClient.Delete(ctx, conversionCACert, metav1.DeleteOptions{})
 }
 
 func DeleteLegacyConversionDeployment(ctx context.Context, identity string) error {

--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -23,7 +23,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 func DeleteNamespace(ctx context.Context, identity string) error {
@@ -135,7 +134,7 @@ func DeleteControllerDeployment(ctx context.Context, identity string) error {
 }
 
 func deleteConversionDeployment(ctx context.Context, identity string) error {
-	return DeleteDeployment(ctx, identity, conversionWebhookName)
+	return DeleteDeployment(ctx, identity, conversionWebhookDeploymentName)
 }
 
 func DeleteDeployment(ctx context.Context, identity, name string) error {
@@ -206,16 +205,5 @@ func DeleteLegacyConversionDeployment(ctx context.Context, identity string) erro
 		return err
 	}
 
-	klog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))
 	return nil
 }
-
-// if err := installer.DeleteConversionSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
-// 	return err
-// }
-
-// if err := installer.DeleteConversionWebhookCertsSecret(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
-// 	return err
-// }
-
-// klog.Infof("'%s' conversion deployment deleted", utils.Bold(identity))

--- a/pkg/node/discovery/discovery.go
+++ b/pkg/node/discovery/discovery.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/klog/v2"
 	"path/filepath"
 	"strings"
-	// "time"
 
 	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta2"
 	"github.com/minio/direct-csi/pkg/clientset"
@@ -66,7 +65,6 @@ func NewDiscovery(ctx context.Context, identity, nodeID, rack, zone, region stri
 		driveTopology:   topologies,
 	}
 
-	// time.Sleep(15*time.Second)
 	if err := d.readRemoteDrives(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/node/discovery/discovery.go
+++ b/pkg/node/discovery/discovery.go
@@ -92,14 +92,16 @@ func (d *Discovery) readRemoteDrives(ctx context.Context) error {
 		d.directcsiClient.DirectV1beta2().DirectCSIDrives(),
 		[]string{d.NodeID}, nil, nil, utils.MaxThreadCount,
 	)
+	klog.Infof("Error: %v", err)
 
 	var remoteDriveList []*remoteDrive
 	for result := range resultCh {
 		if result.Err != nil {
-			return err
+			return result.Err
 		}
 		remoteDriveList = append(remoteDriveList, &remoteDrive{DirectCSIDrive: result.Drive})
 	}
+	klog.Infof("len(remotedrivelist): %v", len(remoteDriveList))
 	d.remoteDrives = remoteDriveList
 	return nil
 }
@@ -113,6 +115,7 @@ func (d *Discovery) Init(ctx context.Context, loopBackOnly bool) error {
 	localDriveStates := d.toDirectCSIDriveStatus(localDrives)
 	var unidentifedDriveStates []directcsi.DirectCSIDriveStatus
 	if len(d.remoteDrives) == 0 {
+		klog.Infof("Creating new drives as remote drives are empty: %v", d.remoteDrives)
 		for _, localDriveState := range localDriveStates {
 			if err := d.createNewDrive(ctx, localDriveState); err != nil {
 				return err

--- a/pkg/utils/list.go
+++ b/pkg/utils/list.go
@@ -54,7 +54,7 @@ func ListDrives(ctx context.Context, driveInterface clientset.DirectCSIDriveInte
 	resultCh := make(chan ListDriveResult)
 	go func() {
 		defer close(resultCh)
-		klog.V(5).InfoS("Listing DirectCSIDrives", "limit", maxObjects, "selectors", labelSelector)
+		klog.V(1).InfoS("Listing DirectCSIDrives", "limit", maxObjects, "selectors", labelSelector)
 
 		send := func(result ListDriveResult) bool {
 			select {
@@ -72,6 +72,7 @@ func ListDrives(ctx context.Context, driveInterface clientset.DirectCSIDriveInte
 		for {
 			result, err := driveInterface.List(ctx, options)
 			if err != nil {
+				klog.Infof("error while listing: %v", err)
 				send(ListDriveResult{Err: err})
 				return
 			}

--- a/pkg/utils/list.go
+++ b/pkg/utils/list.go
@@ -54,7 +54,7 @@ func ListDrives(ctx context.Context, driveInterface clientset.DirectCSIDriveInte
 	resultCh := make(chan ListDriveResult)
 	go func() {
 		defer close(resultCh)
-		klog.V(1).InfoS("Listing DirectCSIDrives", "limit", maxObjects, "selectors", labelSelector)
+		klog.V(5).InfoS("Listing DirectCSIDrives", "limit", maxObjects, "selectors", labelSelector)
 
 		send := func(result ListDriveResult) bool {
 			select {
@@ -72,7 +72,6 @@ func ListDrives(ctx context.Context, driveInterface clientset.DirectCSIDriveInte
 		for {
 			result, err := driveInterface.List(ctx, options)
 			if err != nil {
-				klog.Infof("error while listing: %v", err)
 				send(ListDriveResult{Err: err})
 				return
 			}
@@ -103,7 +102,7 @@ func GetDriveList(ctx context.Context, driveInterface clientset.DirectCSIDriveIn
 	driveList := []directcsi.DirectCSIDrive{}
 	for result := range resultCh {
 		if result.Err != nil {
-			return driveList, err
+			return driveList, result.Err
 		}
 		driveList = append(driveList, result.Drive)
 	}
@@ -177,7 +176,7 @@ func GetVolumeList(ctx context.Context, volumeInterface clientset.DirectCSIVolum
 	volumeList := []directcsi.DirectCSIVolume{}
 	for result := range resultCh {
 		if result.Err != nil {
-			return volumeList, err
+			return volumeList, result.Err
 		}
 		volumeList = append(volumeList, result.Volume)
 	}


### PR DESCRIPTION
- This removes conversion webhook as a separate deployment
- Client side upgrades are removed
- Conversion webhook is moved to node-driver and controller pods running in direct-csi-min-io namespace