### PR TITLE
Delete podsecuritypolicy on uninstallation

### DIFF
--- a/cmd/kubectl-direct_csi/uninstall.go
+++ b/cmd/kubectl-direct_csi/uninstall.go
@@ -222,6 +222,11 @@ func uninstall(ctx context.Context, args []string) error {
 	}
 	klog.Infof("'%s' conversion secrets deleted", utils.Bold(identity))
 
+	if err := installer.DeletePodSecurityPolicy(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	klog.Infof("'%s' pod security policy removed", utils.Bold(identity))
+
 	if err := installer.DeleteNamespace(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/installer/psp.go
+++ b/pkg/installer/psp.go
@@ -116,3 +116,11 @@ func CreatePodSecurityPolicy(ctx context.Context, identity string, dryRun bool) 
 
 	return ErrKubeVersionNotSupported
 }
+
+func removePSPClusterRoleBinding(ctx context.Context, identity string) error {
+	return utils.GetKubeClient().RbacV1().ClusterRoleBindings().Delete(ctx, utils.SanitizeKubeResourceName("psp-"+identity), metav1.DeleteOptions{})
+}
+
+func deletePodSecurityPolicy(ctx context.Context, identity string) error {
+	return utils.GetKubeClient().PolicyV1beta1().PodSecurityPolicies().Delete(ctx, utils.SanitizeKubeResourceName(identity), metav1.DeleteOptions{})
+}

--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -204,3 +204,13 @@ func DeleteLegacyConversionDeployment(ctx context.Context, identity string) erro
 
 	return nil
 }
+
+func DeletePodSecurityPolicy(ctx context.Context, identity string) error {
+	if err := removePSPClusterRoleBinding(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if err := deletePodSecurityPolicy(ctx, identity); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Currently we don't clear the psp upon deletion, This PR fixes it.