### PR TITLE
 Add client adapter for multi-version compatibility 

### DIFF
--- a/cmd/kubectl-direct_csi/drives_accesstier_set.go
+++ b/cmd/kubectl-direct_csi/drives_accesstier_set.go
@@ -96,10 +96,8 @@ func setAccessTier(ctx context.Context, accessTier directcsi.AccessTier) error {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 
-	directCSIClient := client.GetDirectCSIClient()
 	return processFilteredDrives(
 		ctx,
-		directCSIClient.DirectCSIDrives(),
 		nil,
 		func(drive *directcsi.DirectCSIDrive) bool {
 			return drive.Status.DriveStatus != directcsi.DriveStatusUnavailable
@@ -108,7 +106,7 @@ func setAccessTier(ctx context.Context, accessTier directcsi.AccessTier) error {
 			setDriveAccessTier(drive, accessTier)
 			return nil
 		},
-		defaultDriveUpdateFunc(directCSIClient),
+		defaultDriveUpdateFunc(client.GetLatestDirectCSIDriveClientset()),
 		SetAcessTier,
 	)
 }

--- a/cmd/kubectl-direct_csi/drives_accesstier_unset.go
+++ b/cmd/kubectl-direct_csi/drives_accesstier_unset.go
@@ -92,17 +92,15 @@ func unsetAccessTier(ctx context.Context) error {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 
-	directCSIClient := client.GetDirectCSIClient()
 	return processFilteredDrives(
 		ctx,
-		directCSIClient.DirectCSIDrives(),
 		nil,
 		nil,
 		func(drive *directcsi.DirectCSIDrive) error {
 			setDriveAccessTier(drive, directcsi.AccessTierUnknown)
 			return nil
 		},
-		defaultDriveUpdateFunc(directCSIClient),
+		defaultDriveUpdateFunc(client.GetLatestDirectCSIDriveClientset()),
 		UnSetAcessTier,
 	)
 }

--- a/cmd/kubectl-direct_csi/drives_format.go
+++ b/cmd/kubectl-direct_csi/drives_format.go
@@ -105,10 +105,8 @@ func init() {
 }
 
 func formatDrives(ctx context.Context, IDArgs []string) error {
-	directCSIClient := client.GetDirectCSIClient()
 	return processFilteredDrives(
 		ctx,
-		directCSIClient.DirectCSIDrives(),
 		IDArgs,
 		func(drive *directcsi.DirectCSIDrive) bool {
 			if drive.Status.DriveStatus == directcsi.DriveStatusUnavailable {
@@ -149,7 +147,7 @@ func formatDrives(ctx context.Context, IDArgs []string) error {
 			}
 			return nil
 		},
-		defaultDriveUpdateFunc(directCSIClient),
+		defaultDriveUpdateFunc(client.GetLatestDirectCSIDriveClientset()),
 		Format,
 	)
 }

--- a/cmd/kubectl-direct_csi/drives_format_test.go
+++ b/cmd/kubectl-direct_csi/drives_format_test.go
@@ -29,7 +29,6 @@ import (
 
 	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta3"
 	clientsetfake "github.com/minio/direct-csi/pkg/clientset/fake"
-	directcsifake "github.com/minio/direct-csi/pkg/clientset/typed/direct.csi.min.io/v1beta3/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -100,18 +99,18 @@ func TestFormatDrivesByAttributes(t1 *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	testClientSet := clientsetfake.NewSimpleClientset(testDriveObjects...)
-	testClient := testClientSet.DirectV1beta3()
-	client.SetDirectCSIClient(testClient.(*directcsifake.FakeDirectV1beta3))
+	driveInterface := testClientSet.DirectV1beta3().DirectCSIDrives()
+	client.SetUnversionedDirectCSIDriveClientset(driveInterface)
 
 	resetDrives := func() error {
-		driveList, err := client.GetDriveList(ctx, testClient.DirectCSIDrives(), nil, nil, nil)
+		driveList, err := client.GetDriveList(ctx, driveInterface, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 
 		for _, drive := range driveList {
 			drive.Spec.RequestedFormat = nil
-			if _, err := testClient.DirectCSIDrives().Update(ctx, &drive, metav1.UpdateOptions{
+			if _, err := driveInterface.Update(ctx, &drive, metav1.UpdateOptions{
 				TypeMeta: utils.DirectCSIDriveTypeMeta(),
 			}); err != nil {
 				return err
@@ -122,7 +121,7 @@ func TestFormatDrivesByAttributes(t1 *testing.T) {
 	}
 
 	getFormattedDrives := func() ([]string, error) {
-		driveList, err := client.GetDriveList(ctx, testClient.DirectCSIDrives(), nil, nil, nil)
+		driveList, err := client.GetDriveList(ctx, driveInterface, nil, nil, nil)
 		if err != nil {
 			return []string{}, err
 		}

--- a/cmd/kubectl-direct_csi/drives_list.go
+++ b/cmd/kubectl-direct_csi/drives_list.go
@@ -128,7 +128,7 @@ func listDrives(ctx context.Context, args []string) error {
 
 	filteredDrives, err := getFilteredDriveList(
 		ctx,
-		client.GetDirectCSIClient().DirectCSIDrives(),
+		client.GetLatestDirectCSIDriveClientset(),
 		func(drive directcsi.DirectCSIDrive) bool {
 			if len(driveStatusList) > 0 {
 				return drive.MatchDriveStatus(driveStatusList)

--- a/cmd/kubectl-direct_csi/drives_release.go
+++ b/cmd/kubectl-direct_csi/drives_release.go
@@ -98,10 +98,8 @@ func releaseDrives(ctx context.Context, IDArgs []string) error {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 
-	directCSIClient := client.GetDirectCSIClient()
 	return processFilteredDrives(
 		ctx,
-		directCSIClient.DirectCSIDrives(),
 		IDArgs,
 		func(drive *directcsi.DirectCSIDrive) bool {
 			if drive.Status.DriveStatus == directcsi.DriveStatusUnavailable {
@@ -133,7 +131,7 @@ func releaseDrives(ctx context.Context, IDArgs []string) error {
 			drive.Spec.RequestedFormat = nil
 			return nil
 		},
-		defaultDriveUpdateFunc(directCSIClient),
+		defaultDriveUpdateFunc(client.GetLatestDirectCSIDriveClientset()),
 		DriveRelease,
 	)
 }

--- a/cmd/kubectl-direct_csi/info.go
+++ b/cmd/kubectl-direct_csi/info.go
@@ -145,7 +145,7 @@ func getInfo(ctx context.Context, args []string, quiet bool) error {
 
 	drives, err := getFilteredDriveList(
 		ctx,
-		client.GetDirectCSIClient().DirectCSIDrives(),
+		client.GetLatestDirectCSIDriveClientset(),
 		func(drive directcsi.DirectCSIDrive) bool {
 			return drive.Status.DriveStatus == directcsi.DriveStatusInUse || drive.Status.DriveStatus == directcsi.DriveStatusReady
 		},
@@ -157,7 +157,7 @@ func getInfo(ctx context.Context, args []string, quiet bool) error {
 		return err
 	}
 
-	volumes, err := client.GetVolumeList(ctx, client.GetDirectCSIClient().DirectCSIVolumes(), nil, nil, nil, nil)
+	volumes, err := client.GetVolumeList(ctx, client.GetLatestDirectCSIVolumeClientset(), nil, nil, nil, nil)
 	if err != nil {
 		if !quiet {
 			klog.Errorf("error getting volume list: %v", err)

--- a/cmd/kubectl-direct_csi/resource_utils.go
+++ b/cmd/kubectl-direct_csi/resource_utils.go
@@ -31,10 +31,10 @@ func getDrivesByIds(ctx context.Context, ids []string) <-chan client.ListDriveRe
 	resultCh := make(chan client.ListDriveResult)
 	go func() {
 		defer close(resultCh)
-		directClient := client.GetDirectCSIClient()
+		directClient := client.GetLatestDirectCSIDriveClientset()
 		for _, id := range ids {
 			driveName := strings.TrimSpace(id)
-			d, err := directClient.DirectCSIDrives().Get(ctx, driveName, metav1.GetOptions{})
+			d, err := directClient.Get(ctx, driveName, metav1.GetOptions{})
 			if err != nil {
 				if !errors.IsNotFound(err) {
 					klog.ErrorS(err, "could not get drive", driveName)

--- a/cmd/kubectl-direct_csi/utils.go
+++ b/cmd/kubectl-direct_csi/utils.go
@@ -106,7 +106,6 @@ func canonicalNameFromPath(val string) string {
 
 func processFilteredDrives(
 	ctx context.Context,
-	driveInterface clientset.DirectCSIDriveInterface,
 	idArgs []string,
 	matchFunc func(*directcsi.DirectCSIDrive) bool,
 	applyFunc func(*directcsi.DirectCSIDrive) error,
@@ -120,7 +119,7 @@ func processFilteredDrives(
 		defer cancelFunc()
 
 		resultCh, err = client.ListDrives(ctx,
-			driveInterface,
+			client.GetLatestDirectCSIDriveClientset(),
 			nodeSelectorValues,
 			driveSelectorValues,
 			accessTierSelectorValues,
@@ -221,9 +220,9 @@ func getFilteredVolumeList(ctx context.Context, volumeInterface clientset.Direct
 	return filteredVolumes, nil
 }
 
-func defaultDriveUpdateFunc(directCSIClient clientset.DirectV1beta3Interface) func(context.Context, *directcsi.DirectCSIDrive) error {
+func defaultDriveUpdateFunc(directCSIDriveInterface clientset.DirectCSIDriveInterface) func(context.Context, *directcsi.DirectCSIDrive) error {
 	return func(ctx context.Context, drive *directcsi.DirectCSIDrive) error {
-		_, err := directCSIClient.DirectCSIDrives().Update(ctx, drive, metav1.UpdateOptions{})
+		_, err := directCSIDriveInterface.Update(ctx, drive, metav1.UpdateOptions{})
 		return err
 	}
 }

--- a/cmd/kubectl-direct_csi/volumes_list.go
+++ b/cmd/kubectl-direct_csi/volumes_list.go
@@ -86,7 +86,7 @@ func listVolumes(ctx context.Context, args []string) error {
 
 	volumeList, err := getFilteredVolumeList(
 		ctx,
-		client.GetDirectCSIClient().DirectCSIVolumes(),
+		client.GetLatestDirectCSIVolumeClientset(),
 		func(volume directcsi.DirectCSIVolume) bool {
 			return all || utils.IsConditionStatus(volume.Status.Conditions, string(directcsi.DirectCSIVolumeConditionReady), metav1.ConditionTrue)
 		},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/spf13/viper"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -106,7 +105,7 @@ func GetGroupKindVersions(group, kind string, versions ...string) (*schema.Group
 	discoveryClient := GetDiscoveryClient()
 	apiGroupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
 	if err != nil {
-		klog.Errorf("could not obtain API group resources: %v", err)
+		klog.V(3).Infof("could not obtain API group resources: %v", err)
 		return nil, err
 	}
 	restMapper := restmapper.NewDiscoveryRESTMapper(apiGroupResources)
@@ -116,7 +115,7 @@ func GetGroupKindVersions(group, kind string, versions ...string) (*schema.Group
 	}
 	mapper, err := restMapper.RESTMapping(gk, versions...)
 	if err != nil {
-		klog.Errorf("could not find valid restmapping: %v", err)
+		klog.V(3).Infof("could not find valid restmapping: %v", err)
 		return nil, err
 	}
 
@@ -338,20 +337,4 @@ func ProcessDrives(
 		writer,
 		dryRun,
 	)
-}
-
-// DirectCSIDriveTypeMeta gets new direct-csi drive meta.
-func DirectCSIDriveTypeMeta() metav1.TypeMeta {
-	return metav1.TypeMeta{
-		APIVersion: string(utils.DirectCSIVersionLabelKey),
-		Kind:       "DirectCSIDrive",
-	}
-}
-
-// DirectCSIVolumeTypeMeta gets new direct-csi volume meta.
-func DirectCSIVolumeTypeMeta() metav1.TypeMeta {
-	return metav1.TypeMeta{
-		APIVersion: string(utils.DirectCSIVersionLabelKey),
-		Kind:       "DirectCSIVolume",
-	}
 }

--- a/pkg/client/drive-adapter.go
+++ b/pkg/client/drive-adapter.go
@@ -1,0 +1,240 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"context"
+
+	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
+	directv1beta1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
+	directv1beta2 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta2"
+	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta3"
+	clientset "github.com/minio/direct-csi/pkg/clientset/typed/direct.csi.min.io/v1beta3"
+	"github.com/minio/direct-csi/pkg/converter"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+var _ clientset.DirectCSIDriveInterface = &directCSIDriveAdapter{}
+
+type directCSIDriveAdapter struct {
+	resourceInterface dynamic.ResourceInterface
+	gvk               *schema.GroupVersionKind
+}
+
+func directCSIDriveAdapterForConfig(config *rest.Config) (clientset.DirectCSIDriveInterface, error) {
+	gvk, err := GetGroupKindVersions(
+		directcsi.Group,
+		"DirectCSIDrive",
+		directcsi.Version,
+		directv1beta2.Version,
+		directv1beta1.Version,
+		directv1alpha1.Version,
+	)
+	if err != nil && !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+	version := directcsi.Version
+	if gvk != nil {
+		version = gvk.Version
+	}
+	resourceInterface, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	dynamicResourceClient := resourceInterface.Resource(
+		schema.GroupVersionResource{
+			Group:    directcsi.Group,
+			Version:  version,
+			Resource: "directcsidrives",
+		},
+	)
+	return &directCSIDriveAdapter{resourceInterface: dynamicResourceClient, gvk: gvk}, nil
+}
+
+// Get takes name of the directCSIDrive, and returns the latest directCSIDrive object, and an error if there is any.
+func (c *directCSIDriveAdapter) Get(
+	ctx context.Context,
+	name string,
+	options metav1.GetOptions) (*directcsi.DirectCSIDrive, error) {
+	intermediateResult, err := c.resourceInterface.Get(ctx, name, options, "")
+	if err != nil {
+		klog.Infof("could not get intermediate result: %v", err)
+		return nil, err
+	}
+	finalResult := &unstructured.Unstructured{}
+	if err := converter.Migrate(intermediateResult, finalResult, schema.GroupVersion{
+		Version: directcsi.Version,
+		Group:   directcsi.Group,
+	}); err != nil {
+
+		return nil, err
+	}
+	unstructuredObject := finalResult.Object
+	var directCSIDrive directcsi.DirectCSIDrive
+	if err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject, &directCSIDrive); err != nil {
+		return nil, err
+	}
+	return &directCSIDrive, nil
+}
+
+// List takes label and field selectors, and returns the list of DirectCSIDrives that match those selectors.
+func (c *directCSIDriveAdapter) List(ctx context.Context, opts metav1.ListOptions) (result *directcsi.DirectCSIDriveList, err error) {
+	intermediateResult, err := c.resourceInterface.List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	finalResult := &unstructured.UnstructuredList{}
+	err = converter.MigrateList(intermediateResult, finalResult, schema.GroupVersion{
+		Version: directcsi.Version,
+		Group:   directcsi.Group,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var directCSIDriveList directcsi.DirectCSIDriveList
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(finalResult.Object, &directCSIDriveList)
+	if err != nil {
+		return nil, err
+	}
+
+	items := []directcsi.DirectCSIDrive{}
+	for i := range finalResult.Items {
+		directCSIDrive := directcsi.DirectCSIDrive{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(finalResult.Items[i].Object, &directCSIDrive)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, directCSIDrive)
+	}
+	directCSIDriveList.Items = items
+
+	return &directCSIDriveList, nil
+}
+
+// Watch returns a watch.Interface that watches the requested directCSIDrives.
+func (c *directCSIDriveAdapter) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.resourceInterface.Watch(ctx, opts)
+}
+
+// Create takes the representation of a directCSIDrive and creates it.  Returns the server's representation of the directCSIDrive, and an error, if there is any.
+func (c *directCSIDriveAdapter) Create(ctx context.Context, directCSIDrive *directcsi.DirectCSIDrive, opts metav1.CreateOptions) (result *directcsi.DirectCSIDrive, err error) {
+	unstructured := &unstructured.Unstructured{}
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = convertedObj
+
+	createdUnstructuredObj, err := c.resourceInterface.Create(ctx, unstructured, opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var createdDirectCSIDrive directcsi.DirectCSIDrive
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(createdUnstructuredObj.Object, &createdDirectCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	return &createdDirectCSIDrive, nil
+}
+
+// Update takes the representation of a directCSIDrive and updates it. Returns the server's representation of the directCSIDrive, and an error, if there is any.
+func (c *directCSIDriveAdapter) Update(ctx context.Context, directCSIDrive *directcsi.DirectCSIDrive, opts metav1.UpdateOptions) (result *directcsi.DirectCSIDrive, err error) {
+	unstructured := &unstructured.Unstructured{}
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = convertedObj
+
+	updatedUnstructuredObj, err := c.resourceInterface.Update(ctx, unstructured, opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedDirectCSIDrive directcsi.DirectCSIDrive
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredObj.Object, &updatedDirectCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedDirectCSIDrive, nil
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *directCSIDriveAdapter) UpdateStatus(ctx context.Context, directCSIDrive *directcsi.DirectCSIDrive, opts metav1.UpdateOptions) (result *directcsi.DirectCSIDrive, err error) {
+	unstructured := &unstructured.Unstructured{}
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = convertedObj
+
+	updatedUnstructuredObj, err := c.resourceInterface.UpdateStatus(ctx, unstructured, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedDirectCSIDrive directcsi.DirectCSIDrive
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredObj.Object, &updatedDirectCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedDirectCSIDrive, nil
+}
+
+// Delete takes name of the directCSIDrive and deletes it. Returns an error if one occurs.
+func (c *directCSIDriveAdapter) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.resourceInterface.Delete(ctx, name, opts, "")
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *directCSIDriveAdapter) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return c.resourceInterface.DeleteCollection(ctx, opts, listOpts)
+}
+
+// Patch applies the patch and returns the patched directCSIDrive.
+func (c *directCSIDriveAdapter) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *directcsi.DirectCSIDrive, err error) {
+	patchedUnsrtucturedObj, err := c.resourceInterface.Patch(ctx, name, pt, data, opts, subresources...)
+	if err != nil {
+		return nil, err
+	}
+	var patchedDirectCSIDrive directcsi.DirectCSIDrive
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(patchedUnsrtucturedObj.Object, &patchedDirectCSIDrive)
+	if err != nil {
+		return nil, err
+	}
+	return &patchedDirectCSIDrive, nil
+}
+
+// APIVersion returns the APIVersion this RESTClient is expected to use.
+func (c *directCSIDriveAdapter) APIVersion() schema.GroupVersion {
+	return c.gvk.GroupVersion()
+}

--- a/pkg/client/drive.go
+++ b/pkg/client/drive.go
@@ -161,8 +161,7 @@ func DeleteDrive(ctx context.Context, directCSIClient directcsiclientset.Interfa
 	volumeInterface := directCSIClient.DirectV1beta3().DirectCSIVolumes()
 	if drive.Status.DriveStatus != directcsi.DriveStatusTerminating {
 		drive.Status.DriveStatus = directcsi.DriveStatusTerminating
-		drive, err = driveInterface.Update(ctx, drive, metav1.UpdateOptions{TypeMeta: DirectCSIDriveTypeMeta()})
-		if err != nil {
+		if drive, err = driveInterface.Update(ctx, drive, metav1.UpdateOptions{TypeMeta: utils.DirectCSIDriveTypeMeta()}); err != nil {
 			return err
 		}
 	}
@@ -188,7 +187,7 @@ func DeleteDrive(ctx context.Context, directCSIClient directcsiclientset.Interfa
 		}
 
 		drive.Finalizers = []string{}
-		_, err := driveInterface.Update(ctx, drive, metav1.UpdateOptions{TypeMeta: DirectCSIDriveTypeMeta()})
+		_, err := driveInterface.Update(ctx, drive, metav1.UpdateOptions{TypeMeta: utils.DirectCSIDriveTypeMeta()})
 		return err
 	case 0:
 		return nil
@@ -199,7 +198,7 @@ func DeleteDrive(ctx context.Context, directCSIClient directcsiclientset.Interfa
 			}
 			volumeName := strings.TrimPrefix(finalizer, directcsi.DirectCSIDriveFinalizerPrefix)
 			volume, err := volumeInterface.Get(
-				ctx, volumeName, metav1.GetOptions{TypeMeta: DirectCSIVolumeTypeMeta()},
+				ctx, volumeName, metav1.GetOptions{TypeMeta: utils.DirectCSIVolumeTypeMeta()},
 			)
 			if err != nil {
 				return err
@@ -211,7 +210,7 @@ func DeleteDrive(ctx context.Context, directCSIClient directcsiclientset.Interfa
 				"[DRIVE LOST] Please refer https://github.com/minio/direct-csi/blob/master/docs/scheduling.md",
 			)
 			_, err = volumeInterface.Update(
-				ctx, volume, metav1.UpdateOptions{TypeMeta: DirectCSIVolumeTypeMeta()},
+				ctx, volume, metav1.UpdateOptions{TypeMeta: utils.DirectCSIVolumeTypeMeta()},
 			)
 			if err != nil {
 				return err

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -18,7 +18,7 @@ package client
 
 import (
 	clientsetfake "github.com/minio/direct-csi/pkg/clientset/fake"
-	directcsifake "github.com/minio/direct-csi/pkg/clientset/typed/direct.csi.min.io/v1beta3/fake"
+	directcsiclientset "github.com/minio/direct-csi/pkg/clientset/typed/direct.csi.min.io/v1beta3"
 
 	apiextensionsv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,9 +63,12 @@ func FakeInit() {
 	initEvent(kubeClient)
 }
 
-// SetDirectCSIClient sets fake direct-csi client.
-func SetDirectCSIClient(fakeClient *directcsifake.FakeDirectV1beta3) {
-	directCSIClient = fakeClient
+func SetUnversionedDirectCSIDriveClientset(driveInterface directcsiclientset.DirectCSIDriveInterface) {
+	directcsiDriveClientset = driveInterface
+}
+
+func SetUnversionedDirectCSIVolumeClientset(volumeInterface directcsiclientset.DirectCSIVolumeInterface) {
+	directcsiVolumeClientset = volumeInterface
 }
 
 func SetFakeDiscoveryClient(groupsAndMethodsFn fakeServerGroupsAndResourcesMethod, serverVersionInfo *version.Info) {

--- a/pkg/client/init.go
+++ b/pkg/client/init.go
@@ -37,15 +37,27 @@ import (
 const MaxThreadCount = 200
 
 var (
-	initialized         int32
-	kubeClient          kubernetes.Interface
-	directCSIClient     directcsi.DirectV1beta3Interface
-	directClientset     direct.Interface
-	apiextensionsClient apiextensions.ApiextensionsV1Interface
-	crdClient           apiextensions.CustomResourceDefinitionInterface
-	discoveryClient     discovery.DiscoveryInterface
-	metadataClient      metadata.Interface
+	initialized              int32
+	kubeClient               kubernetes.Interface
+	directCSIClient          directcsi.DirectV1beta3Interface
+	directClientset          direct.Interface
+	apiextensionsClient      apiextensions.ApiextensionsV1Interface
+	crdClient                apiextensions.CustomResourceDefinitionInterface
+	discoveryClient          discovery.DiscoveryInterface
+	metadataClient           metadata.Interface
+	directcsiDriveClientset  directcsi.DirectCSIDriveInterface
+	directcsiVolumeClientset directcsi.DirectCSIVolumeInterface
 )
+
+// GetLatestDirectCSIDriveClientset gets unversioned direct-csi drive clientset.
+func GetLatestDirectCSIDriveClientset() directcsi.DirectCSIDriveInterface {
+	return directcsiDriveClientset
+}
+
+// GetLatestDirectCSIVolumeClientset  gets unversioned direct-csi volume clientset.
+func GetLatestDirectCSIVolumeClientset() directcsi.DirectCSIVolumeInterface {
+	return directcsiVolumeClientset
+}
 
 // GetKubeClient gets kube client.
 func GetKubeClient() kubernetes.Interface {
@@ -129,6 +141,18 @@ func Init() {
 	metadataClient, err = metadata.NewForConfig(config)
 	if err != nil {
 		fmt.Printf("%s: could not initialize metadata client: err=%v\n", utils.Bold("Error"), err)
+		os.Exit(1)
+	}
+
+	directcsiDriveClientset, err = directCSIDriveAdapterForConfig(config)
+	if err != nil {
+		fmt.Printf("%s: could not initialize drive adapter client: err=%v\n", utils.Bold("Error"), err)
+		os.Exit(1)
+	}
+
+	directcsiVolumeClientset, err = directCSIVolumeAdapterForConfig(config)
+	if err != nil {
+		fmt.Printf("%s: could not initialize volume adapter client: err=%v\n", utils.Bold("Error"), err)
 		os.Exit(1)
 	}
 

--- a/pkg/client/volume-adapter.go
+++ b/pkg/client/volume-adapter.go
@@ -1,0 +1,241 @@
+// This file is part of MinIO Direct CSI
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"context"
+
+	directv1alpha1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1alpha1"
+	directv1beta1 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta1"
+	directv1beta2 "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta2"
+	directcsi "github.com/minio/direct-csi/pkg/apis/direct.csi.min.io/v1beta3"
+	clientset "github.com/minio/direct-csi/pkg/clientset/typed/direct.csi.min.io/v1beta3"
+	"github.com/minio/direct-csi/pkg/converter"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+var _ clientset.DirectCSIVolumeInterface = &directCSIVolumeAdapter{}
+
+type directCSIVolumeAdapter struct {
+	resourceInterface dynamic.ResourceInterface
+	gvk               *schema.GroupVersionKind
+}
+
+func directCSIVolumeAdapterForConfig(config *rest.Config) (clientset.DirectCSIVolumeInterface, error) {
+	gvk, err := GetGroupKindVersions(
+		directcsi.Group,
+		"DirectCSIVolume",
+		directcsi.Version,
+		directv1beta2.Version,
+		directv1beta1.Version,
+		directv1alpha1.Version,
+	)
+	if err != nil && !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+	version := directcsi.Version
+	if gvk != nil {
+		version = gvk.Version
+	}
+	resourceInterface, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	dynamicResourceClient := resourceInterface.Resource(
+		schema.GroupVersionResource{
+			Group:    directcsi.Group,
+			Version:  version,
+			Resource: "directcsivolumes",
+		},
+	)
+
+	return &directCSIVolumeAdapter{resourceInterface: dynamicResourceClient, gvk: gvk}, nil
+}
+
+// Get takes name of the directCSIVolume, and returns the latest directCSVolume object, and an error if there is any.
+func (c *directCSIVolumeAdapter) Get(
+	ctx context.Context,
+	name string,
+	options metav1.GetOptions) (*directcsi.DirectCSIVolume, error) {
+	intermediateResult, err := c.resourceInterface.Get(ctx, name, options, "")
+	if err != nil {
+		klog.Infof("could not get intermediate result: %v", err)
+		return nil, err
+	}
+	finalResult := &unstructured.Unstructured{}
+	if err := converter.Migrate(intermediateResult, finalResult, schema.GroupVersion{
+		Version: directcsi.Version,
+		Group:   directcsi.Group,
+	}); err != nil {
+
+		return nil, err
+	}
+	unstructuredObject := finalResult.Object
+	var directCSIVolume directcsi.DirectCSIVolume
+	if err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject, &directCSIVolume); err != nil {
+		return nil, err
+	}
+	return &directCSIVolume, nil
+}
+
+// List takes label and field selectors, and returns the list of DirectCSIVolume that match those selectors.
+func (c *directCSIVolumeAdapter) List(ctx context.Context, opts metav1.ListOptions) (result *directcsi.DirectCSIVolumeList, err error) {
+	intermediateResult, err := c.resourceInterface.List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	finalResult := &unstructured.UnstructuredList{}
+	err = converter.MigrateList(intermediateResult, finalResult, schema.GroupVersion{
+		Version: directcsi.Version,
+		Group:   directcsi.Group,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var directCSIVolumeList directcsi.DirectCSIVolumeList
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(finalResult.Object, &directCSIVolumeList)
+	if err != nil {
+		return nil, err
+	}
+
+	items := []directcsi.DirectCSIVolume{}
+	for i := range finalResult.Items {
+		directCSIVolume := directcsi.DirectCSIVolume{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(finalResult.Items[i].Object, &directCSIVolume)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, directCSIVolume)
+	}
+	directCSIVolumeList.Items = items
+
+	return &directCSIVolumeList, nil
+}
+
+// Watch returns a watch.Interface that watches the requested directCSIVolumes.
+func (c *directCSIVolumeAdapter) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.resourceInterface.Watch(ctx, opts)
+}
+
+// Create takes the representation of a directCSIVolume and creates it.  Returns the server's representation of the directCSIVolume, and an error, if there is any.
+func (c *directCSIVolumeAdapter) Create(ctx context.Context, directCSIVolume *directcsi.DirectCSIVolume, opts metav1.CreateOptions) (result *directcsi.DirectCSIVolume, err error) {
+	unstructured := &unstructured.Unstructured{}
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = convertedObj
+
+	createdUnstructuredObj, err := c.resourceInterface.Create(ctx, unstructured, opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var createdDirectCSIVolume directcsi.DirectCSIVolume
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(createdUnstructuredObj.Object, &createdDirectCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	return &createdDirectCSIVolume, nil
+}
+
+// Update takes the representation of a directCSIVolume and updates it. Returns the server's representation of the directCSIVolume, and an error, if there is any.
+func (c *directCSIVolumeAdapter) Update(ctx context.Context, directCSIVolume *directcsi.DirectCSIVolume, opts metav1.UpdateOptions) (result *directcsi.DirectCSIVolume, err error) {
+	unstructured := &unstructured.Unstructured{}
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = convertedObj
+
+	updatedUnstructuredObj, err := c.resourceInterface.Update(ctx, unstructured, opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedDirectCSIVolume directcsi.DirectCSIVolume
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredObj.Object, &updatedDirectCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedDirectCSIVolume, nil
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *directCSIVolumeAdapter) UpdateStatus(ctx context.Context, directCSIVolume *directcsi.DirectCSIVolume, opts metav1.UpdateOptions) (result *directcsi.DirectCSIVolume, err error) {
+	unstructured := &unstructured.Unstructured{}
+	convertedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(directCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = convertedObj
+
+	updatedUnstructuredObj, err := c.resourceInterface.UpdateStatus(ctx, unstructured, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedDirectCSIVolume directcsi.DirectCSIVolume
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredObj.Object, &updatedDirectCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedDirectCSIVolume, nil
+}
+
+// Delete takes name of the directCSIVolume and deletes it. Returns an error if one occurs.
+func (c *directCSIVolumeAdapter) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.resourceInterface.Delete(ctx, name, opts, "")
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *directCSIVolumeAdapter) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return c.resourceInterface.DeleteCollection(ctx, opts, listOpts)
+}
+
+// Patch applies the patch and returns the patched directCSIVolume.
+func (c *directCSIVolumeAdapter) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *directcsi.DirectCSIVolume, err error) {
+	patchedUnsrtucturedObj, err := c.resourceInterface.Patch(ctx, name, pt, data, opts, subresources...)
+	if err != nil {
+		return nil, err
+	}
+	var patchedDirectCSIVolume directcsi.DirectCSIVolume
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(patchedUnsrtucturedObj.Object, &patchedDirectCSIVolume)
+	if err != nil {
+		return nil, err
+	}
+	return &patchedDirectCSIVolume, nil
+}
+
+// APIVersion returns the APIVersion this RESTClient is expected to use.
+func (c *directCSIVolumeAdapter) APIVersion() schema.GroupVersion {
+	return c.gvk.GroupVersion()
+}

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -245,7 +245,6 @@ func TestAbnormalDeleteEventHandle(t *testing.T) {
 	vl := createFakeVolumeEventListener(testObjects...)
 	ctx := context.TODO()
 	directCSIClient := vl.directCSIClient.DirectV1beta3()
-
 	for _, testObj := range testObjects {
 		vObj, ok := testObj.(*directcsi.DirectCSIVolume)
 		if !ok {


### PR DESCRIPTION
Closes #456 

Steps to test 
1. Install `direct-csi` version 1.4.3
```
git checkout v1.4.3
./build.sh
./kubectl-direct_csi --kubeconfig ~/.kube/k3s.yaml install --image direct-csi:v1.4.3
./kubectl-direct_csi --kubeconfig ~/.kube/k3s.yaml  drives list --all -o wide
```
here the server and client bot are on same version so the listing is successful

2. Use the latest client
```
git checkout master
go build ./cmd/kubectl-direct_csi/
./kubectl-direct_csi --kubeconfig ~/.kube/k3s.yaml  drives list --all -o wide
```
This error out stating 
```
Error: the server could not find the requested resource (get directcsidrives.direct.csi.min.io)
ERROR the server could not find the requested resource (get directcsidrives.direct.csi.min.io)
```

3. Use this PR and build the client and then list , format drives , list volumes. It will succeed.


